### PR TITLE
Null character is interpreted as string terminator inside JS/Ruby string

### DIFF
--- a/specmem/object_memspec.rb
+++ b/specmem/object_memspec.rb
@@ -11,4 +11,9 @@ describe V8::C::Object do
       v8_eval('o').object_id.should_not be(old_id)
     end
   end
+
+  it "will include null character in string data" do
+    v8_eval('var o = "\0"')
+    v8_eval('o').Utf8Value().should == "\0"
+  end
 end


### PR DESCRIPTION
When string data containing null characters are used in V8, it thinks it's a string terminator.

For example,

```
>> V8::Context.new.eval("(function() { return \"\0foo\"}())")
=> ""
```
