### PR TITLE
Maybe you can check this PR for gentoo users, needs testing on MacOSX

### DIFF
--- a/ext/v8/extconf.rb
+++ b/ext/v8/extconf.rb
@@ -7,7 +7,6 @@ rescue LoadError
   require 'libv8'
 end
 
-have_library('pthread')
 have_library('objc') if RUBY_PLATFORM =~ /darwin/
 
 #we have to manually prepend the libv8 include path to INCFLAGS
@@ -20,7 +19,7 @@ $CPPFLAGS += " -g" unless $CPPFLAGS.split.include? "-g"
 $CPPFLAGS += " -rdynamic" unless $CPPFLAGS.split.include? "-rdynamic"
 
 $DEFLIBPATH.unshift(Libv8.library_path)
-$LIBS << ' -lv8'
+$LIBS << ' -lv8 -lpthread'
 
 CONFIG['LDSHARED'] = '$(CXX) -shared' unless RUBY_PLATFORM =~ /darwin/
 


### PR DESCRIPTION
For build with  x64 gentoo portage ruby must use lpthread after lv8 or -no-undefined flag will not allow to build
This extconf.rb was tested on Ubuntu Linux, Gentoo. But on FreeBSD i cannot build libv8 for some reason
