### PR TITLE
V8::Object.to_hash method

### DIFF
--- a/lib/v8/object.rb
+++ b/lib/v8/object.rb
@@ -1,4 +1,3 @@
-
 module V8
   class Object
     include Enumerable
@@ -34,6 +33,18 @@ module V8
         end
       end
     end
+    
+  	def to_hash
+			h = {}
+			self.each do |k, v|
+				if v.class == V8::Object
+					h[k.to_s] = v.to_hash
+				else
+					h[k.to_s] = v
+				end
+			end
+			h
+		end
 
     def respond_to?(method)
       self[method] != nil


### PR DESCRIPTION
Recursively converts any JavaScript [object Object] to a Ruby Hash.

I made sure keys are always strings, but I think therubyracer always returns keys as strings, anyway. I just wanted to be sure. So, if it's extra: ditch it.

[Also, this is my first pull request thingy. So, if I'm being weird: sorry!]
