### PR TITLE
Add support for JRuby to test in travis for both Ruby 1.8 and Ruby 1.9 mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 1.8.7
+  - jruby-18mode
+  - jruby-19mode
 notifications:
   recipients:
     - cowboyd@thefrontside.net


### PR DESCRIPTION
Many use JRuby and Rails 3. therubyracer should not fail against JRuby.
