### PR TITLE
Solves #148.

### DIFF
--- a/ext/v8/rr.h
+++ b/ext/v8/rr.h
@@ -1,8 +1,8 @@
 #ifndef _THE_RUBY_RACER_
 #define _THE_RUBY_RACER_ 
 
-#include <ruby.h>
 #include <v8.h>
+#include <ruby.h>
 
 #define rr_define_method(klass, name, impl, argc) rb_define_method(klass, name, (VALUE(*)(...))impl, argc)
 #define rr_define_singleton_method(object, name, impl, argc) rb_define_singleton_method(object, name, (VALUE(*)(...))impl, argc)


### PR DESCRIPTION
In the file rr.h, you first must include v8.h and then ruby.h. Otherwise, the macro StringValue from ruby.h overwrites the StringValue() call in v8.h, so that the preprocessed code looks like this:

Local rb_string_value(&()) const;

which is obviously a syntax error.
I will submit a patch for this (really simple, just swap the two lines).
