### PR TITLE
Change redjs git source to readonly git.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 gemspec
 
-gem 'redjs', :git => 'https://github.com/cowboyd/redjs.git'
+gem 'redjs', :git => 'git://github.com/cowboyd/redjs.git'
 gem "rake"
 gem "rspec", "~> 2.0"
 gem "rake-compiler"


### PR DESCRIPTION
I am using `FreeBSD 9`, and I tried to bundle install `therubyracer`, and always got strange error. 

After change the RedJS git source to Git readonly style, it works.
