### PR TITLE
Fix loading of V8::Conversion classes inside an eigenclass

### DIFF
--- a/lib/v8/conversion.rb
+++ b/lib/v8/conversion.rb
@@ -20,9 +20,10 @@ end
 
 for type in [Class, Object, Array, Hash, String, Symbol, Time, Proc, Method] do
   type.class_eval do
-    include V8::Conversion.const_get(name)
+    include V8::Conversion.const_get(type.name)
   end
 end
+
 class UnboundMethod
   include V8::Conversion::Method
 end

--- a/lib/v8/conversion/class.rb
+++ b/lib/v8/conversion/class.rb
@@ -4,17 +4,19 @@ class V8::Conversion
 
     def to_template
       weakcell(:constructor) do
-        template = V8::C::FunctionTemplate::New(Constructor.new(self))
+        template = V8::C::FunctionTemplate::New(V8::Conversion::ClassActions::Constructor.new(self))
         prototype = template.InstanceTemplate()
-        prototype.SetNamedPropertyHandler(Get, Set)
-        prototype.SetIndexedPropertyHandler(IGet, ISet)
+        prototype.SetNamedPropertyHandler(V8::Conversion::ClassActions::Get, V8::Conversion::ClassActions::Set)
+        prototype.SetIndexedPropertyHandler(V8::Conversion::ClassActions::IGet, V8::Conversion::ClassActions::ISet)
         if self != ::Object && superclass != ::Object && superclass != ::Class
           template.Inherit(superclass.to_template)
         end
         template
       end
     end
+  end
 
+  module ClassActions
     class Constructor
       include V8::Error::Protect
 
@@ -115,6 +117,5 @@ class V8::Conversion
         end
       end
     end
-
   end
 end

--- a/spec/class_scope_spec.rb
+++ b/spec/class_scope_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+# NOTE: This was written to reproduce a bug where V8::Conversion would load the wrong class
+# when inside of an eigen class scope.
+
+# We use Set because ::Set is a existing class and V8::Conversion::Class::Set also exists
+require "set"
+
+describe "Class scope" do
+  it "doesn't try to use V8::Conversion::Class::* as root objects" do
+    klass = Class.new do
+      class << self
+        def test
+          Set.new
+        end
+      end
+    end
+
+    klass.test.should be_instance_of(::Set)
+  end
+end


### PR DESCRIPTION
Because the way code was structured, when trying to use a root object (i.e. ::Set) without the :: prefix, inside a eigenclass, it would load a class of the same name inside V8::Conversion::Class accidentally.

For example:

``` ruby
class Test
  class << self
    def test
      Set.new
    end
  end
end

Test.test # => #<V8::Conversion::Class::Set:0x10592a760>
```
