### PR TITLE
Support IgnoreOutOfMemoryException

### DIFF
--- a/ext/v8/rr.h
+++ b/ext/v8/rr.h
@@ -878,6 +878,7 @@ private:
 class V8 {
 public:
   static void Init();
+  static VALUE IgnoreOutOfMemoryException(VALUE self);
   static VALUE IdleNotification(int argc, VALUE argv[], VALUE self);
   static VALUE SetFlagsFromString(VALUE self, VALUE string);
   static VALUE SetFlagsFromCommandLine(VALUE self, VALUE args, VALUE remove_flags);

--- a/ext/v8/v8.cc
+++ b/ext/v8/v8.cc
@@ -4,6 +4,7 @@ namespace rr {
 
 void V8::Init() {
   ClassBuilder("V8").
+    defineSingletonMethod("IgnoreOutOfMemoryException", &IgnoreOutOfMemoryException).
     defineSingletonMethod("IdleNotification", &IdleNotification).
     defineSingletonMethod("SetFlagsFromString", &SetFlagsFromString).
     defineSingletonMethod("SetFlagsFromCommandLine", &SetFlagsFromCommandLine).
@@ -22,6 +23,9 @@ void V8::Init() {
     defineSingletonMethod("GetVersion", &GetVersion);
 }
 
+VALUE V8::IgnoreOutOfMemoryException(VALUE self) {
+  Void(v8::V8::IgnoreOutOfMemoryException());
+}
 VALUE V8::IdleNotification(int argc, VALUE argv[], VALUE self) {
   VALUE hint;
   rb_scan_args(argc, argv, "01", &hint);

--- a/spec/c/constants_spec.rb
+++ b/spec/c/constants_spec.rb
@@ -17,4 +17,10 @@ describe V8::C do
   it "can access the V8 version" do
     V8::C::V8::GetVersion().should match /^3\.11/
   end
+
+  it "can ignore OOM exceptions" do
+    V8::C::V8::IgnoreOutOfMemoryException()
+    V8::Context.new.eval('var a="0";while(true){a=a+a;}').should be_nil # This context should stop being evaluated at some point, and return nil
+    V8::Context.new.eval('3*4').should be 12 # Other contexts should work just fine
+  end
 end


### PR DESCRIPTION
This is a very small addition exposing more of the underlying C API.
It can be useful to handle OOM cases (otherwise, by default v8 triggers a fatal error, and crashes).
