### PR TITLE
v8 version spec fails after upstream update

### DIFF
--- a/spec/c/constants_spec.rb
+++ b/spec/c/constants_spec.rb
@@ -15,6 +15,6 @@ describe V8::C do
   end
 
   it "can access the V8 version" do
-    V8::C::V8::GetVersion().should match /^3\.11/
+    V8::C::V8::GetVersion().should match /^3\.15/
   end
 end


### PR DESCRIPTION
Just bump the version to 3.15
