### PR TITLE
Update libv8 dependency to 3.11.8.13

### DIFF
--- a/therubyracer.gemspec
+++ b/therubyracer.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.version       = V8::VERSION
 
   gem.add_dependency 'ref'
-  gem.add_dependency 'libv8', '~> 3.15.11.0'
+  gem.add_dependency 'libv8', '~> 3.11.8.13'
 end


### PR DESCRIPTION
From @ignisf, therubyracer 0.11.1 and 0.11.2 require libv8 to be 3.11.8.13. Updating gemspec to reflect change. 
