### PR TITLE
Make it possible to `require "therubyracer"`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ then in your Ruby code
 
     require 'v8'
     # or if using bundler (as with Rails), add the following to your Gemfile
-    gem "therubyracer", :require => 'v8'
+    gem "therubyracer"
 
 evaluate some simple JavaScript
 

--- a/lib/therubyracer.rb
+++ b/lib/therubyracer.rb
@@ -1,0 +1,1 @@
+require "v8"


### PR DESCRIPTION
It's common practice to be able to require the name of the gem. For
example, bundler requires the gem name by default. This removes an
element of surprise when using the gem.
