### PR TITLE
Add license information to gemspec

### DIFF
--- a/therubyracer.gemspec
+++ b/therubyracer.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |gem|
   gem.extensions    = ["ext/v8/extconf.rb"]
   gem.require_paths = ["lib", "ext"]
   gem.version       = V8::VERSION
+  gem.license       = 'MIT'
 
   gem.add_dependency 'ref'
   gem.add_dependency 'libv8', '~> 3.16.14.0'


### PR DESCRIPTION
This increases the discoverability of what license this gem uses. See rubygems/rubygems.org#363 or [this blog post](http://www.benjaminfleischer.com/2013/07/12/make-the-world-a-better-place-put-a-license-in-your-gemspec/) for more info.
