### PR TITLE
Bumped version of libv8 to a Yosemite compatible version

### DIFF
--- a/lib/v8/version.rb
+++ b/lib/v8/version.rb
@@ -1,3 +1,3 @@
 module V8
-  VERSION = "0.12.1"
+  VERSION = "0.12.2"
 end

--- a/therubyracer.gemspec
+++ b/therubyracer.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_dependency 'ref'
-  gem.add_dependency 'libv8', '~> 3.16.14.0'
+  gem.add_dependency 'libv8', '~> 3.16.14.4'
 end


### PR DESCRIPTION
Upgraded a dependency to allow for users running Yosemite to install this gem.

Here is the relevant change: https://github.com/cowboyd/libv8/pull/124
