### PR TITLE
Fix segmentation fault in tests

### DIFF
--- a/spec/c/array_spec.rb
+++ b/spec/c/array_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe V8::C::Array do
+  requires_v8_context
+
   it "can store and retrieve a value" do
     o = V8::C::Object::New()
     a = V8::C::Array::New()

--- a/spec/c/constants_spec.rb
+++ b/spec/c/constants_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe V8::C do
+  requires_v8_context
+
   it "has constant methods for Undefined, Null, True and False" do
     [:Undefined, :Null, :True, :False].each do |name|
       constant = V8::C.send(name)

--- a/spec/c/exception_spec.rb
+++ b/spec/c/exception_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe V8::C::Exception do
+  requires_v8_context
+
   it "can be thrown from Ruby" do
     t = V8::C::FunctionTemplate::New(method(:explode))
     @cxt.Global().Set("explode", t.GetFunction())

--- a/spec/c/external_spec.rb
+++ b/spec/c/external_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe V8::C::External do
+  requires_v8_context
+
   it "can store and retrieve a value" do
     o = Object.new
     external = V8::C::External::New(o)

--- a/spec/c/function_spec.rb
+++ b/spec/c/function_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe V8::C::Function do
+  requires_v8_context
+
   it "can be called" do
     fn = run '(function() {return "foo"})'
     fn.Call(@cxt.Global(), []).Utf8Value().should eql "foo"

--- a/spec/c/handles_spec.rb
+++ b/spec/c/handles_spec.rb
@@ -1,18 +1,14 @@
 require 'spec_helper'
 
 describe "setting up handles scopes" do
-  include ExplicitScoper
-
-  before do
-    def self.instance_eval(*args, &block)
-      V8::C::Locker() do
-        cxt = V8::C::Context::New()
-        begin
-          cxt.Enter()
-          super(*args, &block)
-        ensure
-          cxt.Exit()
-        end
+  around(:each) do |example|
+    V8::C::Locker() do
+      cxt = V8::C::Context::New()
+      begin
+        cxt.Enter()
+        example.run
+      ensure
+        cxt.Exit()
       end
     end
   end

--- a/spec/c/locker_spec.rb
+++ b/spec/c/locker_spec.rb
@@ -1,8 +1,6 @@
 require 'spec_helper'
 
 describe V8::C::Locker do
-  include ExplicitScoper
-
   it "can lock and unlock the VM" do
     V8::C::Locker::IsLocked().should be_false
     V8::C::Locker() do

--- a/spec/c/object_spec.rb
+++ b/spec/c/object_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe V8::C::Object do
+  requires_v8_context
 
   it "can store and retrieve a value" do
     o = V8::C::Object::New()

--- a/spec/c/script_spec.rb
+++ b/spec/c/script_spec.rb
@@ -2,6 +2,8 @@
 require 'spec_helper'
 
 describe V8::C::Script do
+  requires_v8_context
+
   it "can run a script and return a polymorphic result" do
     source = V8::C::String::New("(new Array())")
     filename = V8::C::String::New("<eval>")

--- a/spec/c/string_spec.rb
+++ b/spec/c/string_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe V8::C::String do
+  requires_v8_context
+
   it "can hold Unicode values outside the Basic Multilingual Plane" do
     string = V8::C::String::New("\u{100000}")
     string.Utf8Value().should eql "\u{100000}"

--- a/spec/c/template_spec.rb
+++ b/spec/c/template_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe V8::C::Template do
+  requires_v8_context
 
   describe V8::C::FunctionTemplate do
     it "can be created with no arguments" do

--- a/spec/c/trycatch_spec.rb
+++ b/spec/c/trycatch_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe V8::C::External do
+  requires_v8_context
 
   it "can catch javascript exceptions" do
     V8::C::V8::SetCaptureStackTraceForUncaughtExceptions(true, 99, V8::C::StackTrace::kDetailed)


### PR DESCRIPTION
This fixes segmentation faults in the tests as extending the examples in a before block with override of `#instance_eval` seems to not work. This causes V8 to segfault since the tests try to instantiate objects without a context.

Also, the context wrap is now opt-in with a helper method, instead of being opt-out and relying on `#described_class` (which has slightly different behavior in RSpec 3). This has the added benefit of clarity since the creation of the context wasn't apparent when looking at the examples.

Tested on Ruby 2.1.5 and RSpec 2.99.2. Let me know if you have any comments. :)