### PR TITLE
coordinate shared datastructure teardown

### DIFF
--- a/ext/v8/isolate.cc
+++ b/ext/v8/isolate.cc
@@ -4,42 +4,39 @@
 
 namespace rr {
 
+  VALUE Isolate::Class;
+
   void Isolate::Init() {
     rb_eval_string("require 'v8/retained_objects'");
     ClassBuilder("Isolate").
       defineSingletonMethod("New", &New).
 
       defineMethod("Dispose", &Isolate::Dispose).
-      defineMethod("Equals", &rr::Isolate::PointerEquals).
 
       store(&Class);
   }
 
-
   VALUE Isolate::New(VALUE self) {
     Isolate::IsolateData* data = new IsolateData();
+
     VALUE rb_cRetainedObjects = rb_eval_string("V8::RetainedObjects");
     data->retained_objects = rb_funcall(rb_cRetainedObjects, rb_intern("new"), 0);
 
     v8::Isolate::CreateParams create_params;
     create_params.array_buffer_allocator = &data->array_buffer_allocator;
+    v8::Isolate* isolate = v8::Isolate::New(create_params);
 
-    Isolate isolate(v8::Isolate::New(create_params));
+
     isolate->SetData(0, data);
     isolate->AddGCPrologueCallback(&clearReferences);
 
-    return isolate;
+    data->isolate = isolate;
+    return Isolate(isolate);
   }
 
   VALUE Isolate::Dispose(VALUE self) {
     Isolate isolate(self);
-    delete isolate.data();
     isolate->Dispose();
     return Qnil;
-  }
-
-  template <>
-  void Pointer<v8::Isolate>::unwrap(VALUE value) {
-    Data_Get_Struct(value, class v8::Isolate, pointer);
   }
 }

--- a/spec/c/isolate_spec.rb
+++ b/spec/c/isolate_spec.rb
@@ -7,11 +7,6 @@ describe V8::C::Isolate do
     expect(isolate).to be
   end
 
-  it 'can be tested for equality' do
-    expect(isolate.Equals(isolate)).to eq true
-    expect(isolate.Equals(V8::C::Isolate::New())).to eq false
-  end
-
   it "can be disposed of" do
     isolate.Dispose()
   end

--- a/spec/c_spec_helper.rb
+++ b/spec/c_spec_helper.rb
@@ -22,6 +22,8 @@ module V8ContextHelpers
         @ctx.Exit
       end
     end
+  ensure
+    @isolate.Dispose()
   end
 end
 


### PR DESCRIPTION
This PR takes care of the case where an Isolate was disposed but there were still references outstanding to objects that depended on it. Let's say, for example, that we have

@isolate = V8::C::Isolate::New()
@cxt1 = V8::C::Context::New(@isolate)
@cxt2 = V8::C::Context::New(@isolate)
These objects could be garbage collected in any order, and so it is not safe to delete the underlying Isolate::IsolateData* in the C++ layer, because they are all using the queues contained in it it to coordinate garbage collection.

To solve this, we take a "last one out the door turns off the lights" approach. A concurrent queue is used to track all the outstanding references. Every time a reference is added, an item is pushed onto the queue, and every time a reference is removed, an item is popped off the queue. The last object to get garbage collected will delete the isolate data.

Therefore, the isolate data does not belong to the isolate, but rather to it and all of the Ref<*> objects collectively.

> Originally submitted as https://github.com/stormbreakerbg/therubyracer/pull/7