### PR TITLE
Add support for `Object.Has()`

### DIFF
--- a/ext/v8/object.cc
+++ b/ext/v8/object.cc
@@ -8,6 +8,7 @@ namespace rr {
 
       defineMethod("Set", &Set).
       defineMethod("Get", &Get).
+      defineMethod("Has", &Has).
 
       store(&Class);
   }
@@ -39,6 +40,19 @@ namespace rr {
       return Value::handleToRubyObject(object.getIsolate(), object->Get(UInt32(key)));
     } else {
       return Value::handleToRubyObject(object.getIsolate(), object->Get(*Value(key)));
+    }
+  }
+
+  VALUE Object::Has(VALUE self, VALUE r_context, VALUE key) {
+    Object object(self);
+    Context context(r_context);
+    Locker lock(object.getIsolate());
+    v8::Maybe<bool> does_have(object->Has(context, *Value(key)));
+
+    if (does_have.IsNothing()) {
+      return Qnil;
+    } else {
+      return does_have.FromJust() ? Qtrue : Qfalse;
     }
   }
 

--- a/ext/v8/object.h
+++ b/ext/v8/object.h
@@ -11,7 +11,7 @@ namespace rr {
     // static VALUE ForceSet(VALUE self, VALUE key, VALUE value);
     static VALUE Get(VALUE self, VALUE key);
     // static VALUE GetPropertyAttributes(VALUE self, VALUE key);
-    // static VALUE Has(VALUE self, VALUE key);
+    static VALUE Has(VALUE self, VALUE context, VALUE key);
     // static VALUE Delete(VALUE self, VALUE key);
     // static VALUE ForceDelete(VALUE self, VALUE key);
     // static VALUE SetAccessor(int argc, VALUE* argv, VALUE self);

--- a/spec/c/object_spec.rb
+++ b/spec/c/object_spec.rb
@@ -16,6 +16,16 @@ describe V8::C::Object do
     expect(o.Get(key).Utf8Value).to eq 'bar'
   end
 
+  it "checks for key presence" do
+    o = V8::C::Object::New(@isolate)
+    key = V8::C::String.NewFromUtf8(@isolate, 'foo')
+    value = V8::C::String.NewFromUtf8(@isolate, 'bar')
+
+    expect(o.Has(@context, key)).to eq false
+    o.Set(key, value)
+    expect(o.Has(@context, key)).to eq true
+  end
+
   # TODO: Enable this when the methods are implemented in the extension
   # it 'can retrieve all property names' do
   #   o = V8::C::Object.New


### PR DESCRIPTION
> Note: This was originally opened as https://github.com/stormbreakerbg/therubyracer/pull/5

The old method that did not take a context was deprecated, so we implemented it with this one.

However it returns a Maybe<bool>. We weren't sure what to return in the cause of IsNothing() returning true. So we return nil, but maybe we want to throw an exception?