### PR TITLE
only run C spec compiled with Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ rvm:
   - 1.8.7
   - rbx-2.2.3
 env: CXX=clang++
+matrix:
+  allow_failures:
+    - rvm: 1.9.3
+    - rvm: 1.9.2
+    - rvm: 1.8.7
 notifications:
   recipients:
     - cowboyd@thefrontside.net

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ rvm:
   - 1.9.2
   - 1.8.7
   - rbx-2.2.3
-env:
-  - CXX=g++-4.8
-  - CC=gcc-4.8
 matrix:
   allow_failures:
     - rvm: 1.9.3
@@ -20,9 +17,7 @@ notifications:
 before_install:
   - gem update --system 2.1.11
 script:
-  - $CXX --version
-  - $CC --version
-  - bundle exec rake compile
+  - CXX=g++-4.8 bundle exec rake compile
   - bundle exec rspec spec/c
 sudo: false
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-cache: bundler
+#cache: bundler
 rvm:
   - 2.1.0
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ rvm:
   - 1.9.2
   - 1.8.7
   - rbx-2.2.3
-env:
-  - CC=clang
-  - CXX=clang++
 matrix:
   allow_failures:
     - rvm: 1.9.3
@@ -27,7 +24,8 @@ compiler:
   - gcc
   - clang
 install:
-- if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  - bundle install
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,12 @@ rvm:
   - 1.9.2
   - 1.8.7
   - rbx-2.2.3
+env: CXX=clang++
 notifications:
   recipients:
     - cowboyd@thefrontside.net
 before_install:
   - gem update --system 2.1.11
-script: bundle exec rake compile spec
+script:
+  - bundle exec rake compile
+  - bundle exec rspec spec/c

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 1.9.2
   - 1.8.7
   - rbx-2.2.3
+env: CXX=g++-4.8
 matrix:
   allow_failures:
     - rvm: 1.9.3
@@ -20,12 +21,6 @@ script:
   - bundle exec rake compile
   - bundle exec rspec spec/c
 sudo: false
-compiler:
-  - gcc
-  - clang
-install:
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
-  - bundle install
 addons:
   apt:
     sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - rvm: 1.9.3
     - rvm: 1.9.2
     - rvm: 1.8.7
+    - rvm: rbx-2.2.3
 env:
   - CXX=g++-4.8
   - CXX=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,17 @@ before_install:
 script:
   - bundle exec rake compile
   - bundle exec rspec spec/c
+sudo: false
+compiler:
+  - gcc
+  - clang
+install:
+- if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8
+    - g++-4.8
+    - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ notifications:
 before_install:
   - gem update --system 2.1.11
 script:
-  - CXX=g++-4.8 bundle exec rake compile
+  - bundle exec rake compile
   - bundle exec rspec spec/c
 sudo: false
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 1.9.2
   - 1.8.7
   - rbx-2.2.3
-env: CXX=g++-4.8
+env: CXX=clang++
 matrix:
   allow_failures:
     - rvm: 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ notifications:
 before_install:
   - gem update --system 2.1.11
 script:
+  - g++ --version
+  - clang++ --version
   - bundle exec rake compile
   - bundle exec rspec spec/c
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 1.9.2
   - 1.8.7
   - rbx-2.2.3
-env: CXX=clang++
+env: CXX=g++-4.8
 matrix:
   allow_failures:
     - rvm: 1.9.3
@@ -19,7 +19,9 @@ before_install:
   - gem update --system 2.1.11
 script:
   - g++ --version
+  - g++-4.8 --version
   - clang++ --version
+  - ls /usr/bin/clang*
   - bundle exec rake compile
   - bundle exec rspec spec/c
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ notifications:
 before_install:
   - gem update --system 2.1.11
 script:
-  - $(CXX) --version
-  - $(CC) --version
+  - $CXX --version
+  - $CC --version
   - bundle exec rake compile
   - bundle exec rspec spec/c
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ rvm:
   - 1.9.2
   - 1.8.7
   - rbx-2.2.3
-env: CXX=g++-4.8
+env:
+  - CXX=g++-4.8
+  - CC=gcc-4.8
 matrix:
   allow_failures:
     - rvm: 1.9.3
@@ -18,10 +20,8 @@ notifications:
 before_install:
   - gem update --system 2.1.11
 script:
-  - g++ --version
-  - g++-4.8 --version
-  - clang++ --version
-  - ls /usr/bin/clang*
+  - $(CXX) --version
+  - $(CC) --version
   - bundle exec rake compile
   - bundle exec rspec spec/c
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ rvm:
   - 1.9.2
   - 1.8.7
   - rbx-2.2.3
-env: CXX=clang++
+env:
+  - CC=clang
+  - CXX=clang++
 matrix:
   allow_failures:
     - rvm: 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ matrix:
     - rvm: 1.9.3
     - rvm: 1.9.2
     - rvm: 1.8.7
+env:
+  - CXX=g++-4.8
+  - CXX=clang++
 notifications:
   recipients:
     - cowboyd@thefrontside.net

--- a/ext/v8/extconf.rb
+++ b/ext/v8/extconf.rb
@@ -1,4 +1,5 @@
 require 'mkmf'
+RbConfig::MAKEFILE_CONFIG['CXX'] = ENV['CXX'] if ENV['CXX']
 
 have_library('pthread')
 have_library('objc') if RUBY_PLATFORM =~ /darwin/

--- a/ext/v8/extconf.rb
+++ b/ext/v8/extconf.rb
@@ -10,7 +10,6 @@ $CPPFLAGS += " -rdynamic" unless $CPPFLAGS.split.include? "-rdynamic" unless RUB
 $CPPFLAGS += " -fPIC" unless $CPPFLAGS.split.include? "-rdynamic" or RUBY_PLATFORM =~ /darwin/
 $CPPFLAGS += " -std=c++11"
 
-
 if cxx =~ /clang/
    $LDFLAGS += " -stdlib=libstdc++"
 end

--- a/ext/v8/extconf.rb
+++ b/ext/v8/extconf.rb
@@ -1,5 +1,5 @@
 require 'mkmf'
-RbConfig::MAKEFILE_CONFIG['CXX'] = ENV['CXX'] if ENV['CXX']
+cxx = RbConfig::MAKEFILE_CONFIG['CXX'] = ENV['CXX'] if ENV['CXX']
 
 have_library('pthread')
 have_library('objc') if RUBY_PLATFORM =~ /darwin/
@@ -10,7 +10,10 @@ $CPPFLAGS += " -rdynamic" unless $CPPFLAGS.split.include? "-rdynamic" unless RUB
 $CPPFLAGS += " -fPIC" unless $CPPFLAGS.split.include? "-rdynamic" or RUBY_PLATFORM =~ /darwin/
 $CPPFLAGS += " -std=c++11"
 
-$LDFLAGS += " -stdlib=libstdc++"
+
+if cxx =~ /clang/
+   $LDFLAGS += " -stdlib=libstdc++"
+end
 
 CONFIG['LDSHARED'] = '$(CXX) -shared' unless RUBY_PLATFORM =~ /darwin/
 if CONFIG['warnflags']


### PR DESCRIPTION
In order to make sure we have valid failures on this branch, and not
just a bunch of false negatives, we're only running the C specs, and
building with clang. Eventually, we'll merge in support for gcc and more
of the test suite.

For now, we want to only include the specs we things should be passing