### PR TITLE
add support for Maybe APIs.

### DIFF
--- a/ext/v8/bool.h
+++ b/ext/v8/bool.h
@@ -58,7 +58,7 @@ namespace rr {
      * Use when you need to convert v8::Maybe<bool> into a VALUE. E.g.
      *   return Bool::Maybe(object->ReturnsMaybeSomething());
      */
-    typedef Maybe<bool, Bool> Maybe;
+    typedef rr::Maybe<bool, Bool> Maybe;
   };
 }
 

--- a/ext/v8/bool.h
+++ b/ext/v8/bool.h
@@ -53,6 +53,12 @@ namespace rr {
     inline operator bool() {
       return RTEST(value);
     }
+
+    /**
+     * Use when you need to convert v8::Maybe<bool> into a VALUE. E.g.
+     *   return Bool::Maybe(object->ReturnsMaybeSomething());
+     */
+    typedef Maybe<bool, Bool> Maybe;
   };
 }
 

--- a/ext/v8/equiv.h
+++ b/ext/v8/equiv.h
@@ -44,6 +44,15 @@ namespace rr {
     VALUE value;
   };
 
+  /**
+   * Convert `int`s into `VALUE`. To unbox v8::Maybe<int>, use
+   * Int::Maybe().
+   */
+  class Int : public Equiv {
+    Int(int i) : Equiv(INT2FIX(i)) {}
+
+    class Maybe : rr::Maybe<int, Int> {};
+  };
 }
 
 #endif

--- a/ext/v8/init.cc
+++ b/ext/v8/init.cc
@@ -25,6 +25,8 @@ extern "C" {
     Array::Init();
     External::Init();
 
+
+
     // Accessor::Init();
     // Invocation::Init();
     // Signature::Init();
@@ -38,5 +40,7 @@ extern "C" {
     // Exception::Init();
     // ResourceConstraints::Init();
     // HeapStatistics::Init();
+
+    MaybeInit::Init();
   }
 }

--- a/ext/v8/integer.h
+++ b/ext/v8/integer.h
@@ -1,0 +1,48 @@
+// -*- mode: c++ -*-
+#ifndef RR_INTEGER_H
+#define RR_INTEGER_H
+
+namespace rr {
+  class Integer : public Ref<v8::Integer> {
+  public:
+    Integer(v8::Isolate* isolate, v8::Handle<v8::Integer> integer) :
+      Ref<v8::Integer>(isolate, integer) {}
+    Integer(VALUE self) :
+      Ref<v8::Integer>(self) {}
+    class Maybe : MaybeLocal<v8::Integer, Integer> {};
+
+    static VALUE New(VALUE self, VALUE r_isolate, VALUE value) {
+      Isolate isolate(r_isolate);
+      Locker lock(isolate);
+
+      v8::Local<v8::Integer> i = v8::Integer::New(isolate, NUM2INT(value));
+      return Value::handleToRubyObject(isolate, i);
+    }
+
+    static VALUE NewFromUnsigned(VALUE self, VALUE r_isolate, VALUE value) {
+      Isolate isolate(r_isolate);
+      Locker lock(isolate);
+
+      uint32_t uint = NUM2UINT(value);
+      v8::Local<v8::Integer> i = v8::Integer::NewFromUnsigned(isolate, uint);
+      return Value::handleToRubyObject(isolate, i);
+    }
+
+    static VALUE Value(VALUE self) {
+      Integer integer(self);
+      Locker lock(integer);
+
+      return INT2NUM(integer->Value());
+    }
+
+    static void Init() {
+      ClassBuilder("Integer", Number::Class).
+        defineSingletonMethod("New", &New).
+        defineSingletonMethod("NewFromUnsigned", &NewFromUnsigned).
+        defineMethod("Value", &Value).
+        store(&Class);
+    }
+  };
+}
+
+#endif /* RR_INTEGER_H */

--- a/ext/v8/isolate.cc
+++ b/ext/v8/isolate.cc
@@ -10,7 +10,7 @@ namespace rr {
       defineSingletonMethod("New", &New).
 
       defineMethod("Dispose", &Isolate::Dispose).
-      defineMethod("Equals", &rr::Isolate::PointerEquals).
+      defineMethod("ThrowException", &ThrowException).
 
       store(&Class);
   }
@@ -36,6 +36,13 @@ namespace rr {
     delete isolate.data();
     isolate->Dispose();
     return Qnil;
+  }
+
+  VALUE Isolate::ThrowException(VALUE self, VALUE exception) {
+    Isolate isolate(self);
+    Locker lock(isolate);
+
+    return Value::handleToRubyObject(isolate, isolate->ThrowException(Value(exception)));
   }
 
   template <>

--- a/ext/v8/isolate.h
+++ b/ext/v8/isolate.h
@@ -29,6 +29,8 @@ namespace rr {
     static void Init();
 
     static VALUE New(VALUE self);
+    static VALUE Dispose(VALUE self);
+    static VALUE ThrowException(VALUE self, VALUE r_exception);
 
     inline Isolate(v8::Isolate* isolate) : Pointer<v8::Isolate>(isolate) {}
     inline Isolate(VALUE value) : Pointer<v8::Isolate>(value) {}
@@ -123,9 +125,6 @@ namespace rr {
         delete cell;
       }
     }
-
-
-    static VALUE Dispose(VALUE self);
 
     /**
      * Recent versions of V8 will segfault unless you pass in an

--- a/ext/v8/maybe.h
+++ b/ext/v8/maybe.h
@@ -1,0 +1,82 @@
+// -*- mode: c++ -*-
+#ifndef RR_MAYBE_H
+#define RR_MAYBE_H
+
+
+/**
+ * Helpers to deal with V8 apis that may or may not return values
+ * because they have an exception pending. They come in too flavors:
+ * One for simple C++ values, and other for persistent
+ * references. These correspond to the v8::Maybe, and v8::MaybeLocal
+ * classes.
+ *
+ * When you unbox a return value with a `Maybe` or a `MaybeLocal`, it
+ * will check to see if there is a value. If so, it returns the
+ * value. If not, it raises an instance of `V8::C::PendingExceptionError`
+ *
+ * To use, provide the template with two classes: 1) the v8 internal
+ * class that underlying method returns, and 2) the converter class that
+ * will convert it into a Ruby `VALUE`. For example, to wrap a call to
+ * `v8::Maybe<bool> Has(v8::Local<v8::Context> context)` in the class
+ * `v8::Object`, you would want to say something like:
+ *
+ *   return Maybe<bool,Bool>(object->Has(context, key));
+ *
+ * In practice, in the code, you'll usually see a typedef so that you
+ * don't have to constantly type out the same template parameters over
+ * and over again. So in the example above Bool::Maybe is typedef'd to
+ * Maybe<bool, Bool>, so you could also have written:
+ *
+ *   return Bool::Maybe(object->Has(context, key));
+ */
+namespace rr {
+  /**
+   * Holds the Ruby exception class for `V8::C::PendingExceptionError`
+   */
+  static VALUE PendingExceptionError;
+
+  template <class T, class E>
+  class Maybe {
+  public:
+    Maybe(v8::Maybe<T>& maybe_) : maybe(maybe_) {}
+
+    inline operator VALUE() {
+      if (maybe.IsNothing()) {
+        rb_raise(PendingExceptionError, "operation cannot be performed due to a pending exception in this context\n");
+        return Qnil;
+      } else {
+        return E(maybe.FromJust());
+      }
+    }
+
+    v8::Maybe<T>  maybe;
+  };
+
+  template <class T, class R>
+  class MaybeLocal {
+  public:
+    MaybeLocal(v8::Isolate* isolate_, v8::MaybeLocal<T> maybe_) :
+      isolate(isolate_), maybe(maybe_) {}
+
+    inline operator VALUE() {
+      if (maybe.IsEmpty()) {
+        rb_raise(PendingExceptionError, "operation cannot be performed due to a pending exception in this context\n");
+        return Qnil;
+      } else {
+        return R(isolate, maybe.ToLocalChecked());
+      }
+    }
+    v8::Isolate* isolate;
+    v8::MaybeLocal<T> maybe;
+  };
+
+  class MaybeInit {
+  public:
+    static void Init() {
+      ClassBuilder("PendingExceptionError", rb_eStandardError).
+        store(&PendingExceptionError);
+    }
+  };
+};
+
+#endif /* RR_MAYBE_H */

--- a/ext/v8/rr.h
+++ b/ext/v8/rr.h
@@ -18,6 +18,7 @@ inline VALUE not_implemented(const char* message) {
 
 #include "class_builder.h"
 
+#include "maybe.h"
 #include "equiv.h"
 #include "bool.h"
 #include "pointer.h"

--- a/ext/v8/rr_string.h
+++ b/ext/v8/rr_string.h
@@ -14,6 +14,8 @@ namespace rr {
     inline String(VALUE value) : Ref<v8::String>(value) {}
     inline String(v8::Isolate* isolate, v8::Handle<v8::String> string) : Ref<v8::String>(isolate, string) {}
 
+    typedef MaybeLocal<v8::String, String> Maybe;
+
     virtual operator v8::Handle<v8::String>() const;
   };
 

--- a/ext/v8/value.cc
+++ b/ext/v8/value.cc
@@ -118,11 +118,12 @@ namespace rr {
     return Bool(value->IsUint32());
   }
 
-  VALUE Value::ToString(VALUE self) {
+  VALUE Value::ToString(VALUE self, VALUE r_context) {
     Value value(self);
+    v8::Local<v8::Context> context((Context(r_context)));
     Locker lock(value.getIsolate());
 
-    return String(value.getIsolate(), value->ToString());
+    return String::Maybe(value.getIsolate(), value->ToString(context));
   }
 
   VALUE Value::Equals(VALUE self, VALUE other) {

--- a/ext/v8/value.h
+++ b/ext/v8/value.h
@@ -51,7 +51,7 @@ namespace rr {
 
     static VALUE Empty;
 
-    typedef Ref<v8::Value>::Maybe<Value> Maybe;
+    typedef MaybeLocal<v8::Value, Value> Maybe;
   };
 
 }

--- a/ext/v8/value.h
+++ b/ext/v8/value.h
@@ -26,7 +26,7 @@ namespace rr {
     // static VALUE IsStringObject(VALUE self);
     // static VALUE IsNativeError(VALUE self);
     // static VALUE IsRegExp(VALUE self);
-    static VALUE ToString(VALUE self);
+    static VALUE ToString(VALUE self, VALUE context);
     // static VALUE ToDetailString(VALUE self);
     // static VALUE ToObject(VALUE self);
     // static VALUE BooleanValue(VALUE self);
@@ -50,6 +50,8 @@ namespace rr {
     static std::vector< v8::Handle<v8::Value> > convertRubyArray(v8::Isolate* isolate, VALUE value);
 
     static VALUE Empty;
+
+    typedef Ref<v8::Value>::Maybe<Value> Maybe;
   };
 
 }

--- a/spec/c/function_spec.rb
+++ b/spec/c/function_spec.rb
@@ -6,7 +6,7 @@ describe V8::C::Function do
   it "has a script origin" do
     fn = run '(function() { return "foo" })'
     origin = fn.GetScriptOrigin()
-    expect(origin.ResourceName().ToString().Utf8Value()).to eql 'undefined'
+    expect(origin.ResourceName().ToString(@context).Utf8Value()).to eql 'undefined'
     expect(origin.ResourceLineOffset()).to eql 0
     expect(origin.ResourceColumnOffset()).to eql 0
   end

--- a/spec/c/isolate_spec.rb
+++ b/spec/c/isolate_spec.rb
@@ -7,11 +7,6 @@ describe V8::C::Isolate do
     expect(isolate).to be
   end
 
-  it 'can be tested for equality' do
-    expect(isolate.Equals(isolate)).to eq true
-    expect(isolate.Equals(V8::C::Isolate::New())).to eq false
-  end
-
   it "can be disposed of" do
     isolate.Dispose()
   end

--- a/spec/c/maybe_spec.rb
+++ b/spec/c/maybe_spec.rb
@@ -1,0 +1,16 @@
+require 'c_spec_helper'
+
+describe "maybe APIs" do
+  requires_v8_context
+
+  before do
+    @isolate.ThrowException(V8::C::String::NewFromUtf8(@isolate, "boom!"))
+  end
+
+  let(:object) { object = V8::C::Object.New(@isolate) }
+
+  it "throws an error when you want to " do
+    object.ToString(@context)
+  end
+
+end


### PR DESCRIPTION
This adds some conversion classes to automatically unbox both
`Maybe<T>`, and `MaybeLocal<T>` values, which lays the basis for https://github.com/cowboyd/therubyracer/pull/354 (originally https://github.com/stormbreakerbg/therubyracer/pull/5) 

 In general, you take the conversion class, and access the `::Maybe` class underneath it. For
example, to unbox values of `v8::Maybe<v8::String>`, you'd use `String::Maybe()`

This PR doesn't add *all* the helpers, but some and an example in the implementation of the `v8::String.ToString()` method.

I've tried to get a failing test in `spec/c/maybe_spec` but can't seem to do it. 