### PR TITLE
Maybe APIs

### DIFF
--- a/ext/v8/bool.h
+++ b/ext/v8/bool.h
@@ -24,6 +24,14 @@ namespace rr {
   class Bool : public Equiv {
   public:
     /**
+     * Use to convert methods that return Maybe<bool> to a Ruby
+     * VALUE, Such as `Maybe<bool> v8::Object::Get()`:
+     *
+     *   return Bool::Maybe(object->Get(context, key));
+     */
+    typedef Equiv::Maybe<bool, Bool> Maybe;
+
+    /**
      * Construct a Bool from a Ruby VALUE
      */
     Bool(VALUE val) : Equiv(val) {}

--- a/ext/v8/equiv.h
+++ b/ext/v8/equiv.h
@@ -40,6 +40,27 @@ namespace rr {
      */
     inline operator VALUE() { return value; }
 
+
+    /**
+     * A Maybe class for primitive conversions. Specify the primitive
+     * type and the covversion type, and it will be wrapped in a
+     * Maybe. E.g.
+     *
+     *   v8::Maybe<bool> maybe = methodReturningMaybeBool();
+     *   return Equiv::Maybe<bool, Bool>(maybe);
+     *
+     * will yield a V8::C::Maybe wrapping the underlying maybe value.
+     */
+    template <class T, class S>
+    class Maybe : public rr::Maybe {
+    public:
+      Maybe(v8::Maybe<T> maybe) {
+        if (maybe.IsJust()) {
+          just(S(maybe.FromJust()));
+        }
+      }
+    };
+
   protected:
     VALUE value;
   };

--- a/ext/v8/init.cc
+++ b/ext/v8/init.cc
@@ -13,6 +13,7 @@ extern "C" {
     Handles::Init();
     Context::Init();
     Backref::Init();
+    Maybe::Init();
     Value::Init();
     Object::Init();
     Primitive::Init();

--- a/ext/v8/maybe.cc
+++ b/ext/v8/maybe.cc
@@ -1,0 +1,6 @@
+#include "rr.h"
+
+namespace rr {
+  VALUE Maybe::JustClass;
+  VALUE Maybe::Nothing;
+}

--- a/ext/v8/maybe.h
+++ b/ext/v8/maybe.h
@@ -1,0 +1,71 @@
+// -*- mode: c++ -*-
+#ifndef RR_MAYBE_H
+#define RR_MAYBE_H
+
+namespace rr {
+
+  /**
+   * A base class for conversion objects that will return an instance
+   * of `V8::C::Maybe` depending on whether a value is available.
+   *
+   * Sprinkled throughout the V8 API, there are methods that may or
+   * may not return a value based on whether there is an Exception
+   * that is pending in the context of that operation.
+   *
+   * This class provides the basis for helpers to convert the C++
+   * Maybe<T> and MaybeLocal<T> objects into Ruby objects that force
+   * you to check if an operation suceeded.
+   *
+   * By default, it will be `V8::C::Nothing`, but if, in the
+   * constructor, you call `just(VALUE value)`, then it will take on
+   * that value.
+   */
+  class Maybe {
+  public:
+
+    /**
+     * V8::C::Just
+     */
+    static VALUE JustClass;
+
+    /**
+     * Singleton instance of `V8::C::Nothing`
+     */
+    static VALUE Nothing;
+
+    /**
+     * By default, everything starts out as nothing.
+     */
+    Maybe() : object(Nothing) {}
+
+    /**
+     * Convert this seemlessly to a VALUE, which in this case is just
+     * the v8::C::Maybe ruby instance.
+     */
+    inline operator VALUE() {
+      return object;
+    }
+
+    static inline void Init() {
+      rb_eval_string("require 'v8/c/maybe'");
+      JustClass = rb_eval_string("::V8::C::Maybe::Just");
+      Nothing = rb_eval_string("::V8::C::Maybe.nothing");
+    }
+
+  protected:
+
+    /**
+     * Subclasses call this method in the constructor in order to
+     * indicate that this is a `V8::C::Just`, and to pass the
+     * underlying value.
+     */
+    inline void just(VALUE v) {
+      object = rb_funcall(JustClass, rb_intern("new"), 1, v);
+    }
+
+    // the underlying value.
+    VALUE object;
+  };
+}
+
+#endif /* RR_MAYBE_H */

--- a/ext/v8/object.cc
+++ b/ext/v8/object.cc
@@ -20,25 +20,29 @@ namespace rr {
   }
 
   // TODO: Allow setting of property attributes
-  VALUE Object::Set(VALUE self, VALUE key, VALUE value) {
+  VALUE Object::Set(VALUE self, VALUE r_context, VALUE key, VALUE value) {
     Object object(self);
-    Locker lock(object.getIsolate());
+    Context context(r_context);
+    Isolate isolate(object.getIsolate());
+    Locker lock(isolate);
 
     if (rb_obj_is_kind_of(key, rb_cNumeric)) {
-      return Bool(object->Set(UInt32(key), Value::rubyObjectToHandle(object.getIsolate(), value)));
+      return Bool::Maybe(object->Set(context, UInt32(key), Value::rubyObjectToHandle(isolate, value)));
     } else {
-      return Bool(object->Set(*Value(key), Value::rubyObjectToHandle(object.getIsolate(), value)));
+      return Bool::Maybe(object->Set(context, *Value(key), Value::rubyObjectToHandle(isolate, value)));
     }
   }
 
-  VALUE Object::Get(VALUE self, VALUE key) {
+  VALUE Object::Get(VALUE self, VALUE r_context, VALUE key) {
     Object object(self);
-    Locker lock(object.getIsolate());
+    Context context(r_context);
+    Isolate isolate(object.getIsolate());
+    Locker lock(isolate);
 
     if (rb_obj_is_kind_of(key, rb_cNumeric)) {
-      return Value::handleToRubyObject(object.getIsolate(), object->Get(UInt32(key)));
+      return Value::Maybe(isolate, object->Get(context, UInt32(key)));
     } else {
-      return Value::handleToRubyObject(object.getIsolate(), object->Get(*Value(key)));
+      return Value::Maybe(isolate, object->Get(context, *Value(key)));
     }
   }
 

--- a/ext/v8/object.h
+++ b/ext/v8/object.h
@@ -7,9 +7,9 @@ namespace rr {
   public:
     static void Init();
     static VALUE New(VALUE self, VALUE isolate);
-    static VALUE Set(VALUE self, VALUE key, VALUE value);
+    static VALUE Set(VALUE self, VALUE context, VALUE key, VALUE value);
     // static VALUE ForceSet(VALUE self, VALUE key, VALUE value);
-    static VALUE Get(VALUE self, VALUE key);
+    static VALUE Get(VALUE self, VALUE context, VALUE key);
     // static VALUE GetPropertyAttributes(VALUE self, VALUE key);
     // static VALUE Has(VALUE self, VALUE key);
     // static VALUE Delete(VALUE self, VALUE key);

--- a/ext/v8/rr.h
+++ b/ext/v8/rr.h
@@ -17,7 +17,7 @@ inline VALUE not_implemented(const char* message) {
 }
 
 #include "class_builder.h"
-
+#include "maybe.h"
 #include "equiv.h"
 #include "bool.h"
 #include "pointer.h"

--- a/ext/v8/value.h
+++ b/ext/v8/value.h
@@ -1,3 +1,4 @@
+// -*- mode: c++ -*-
 #ifndef RR_VALUE
 #define RR_VALUE
 
@@ -5,6 +6,23 @@ namespace rr {
 
   class Value : public Ref<v8::Value> {
   public:
+    /**
+     * A conversion class for down-thunking a MaybeLocal<v8::Value>
+     * and returning it to Ruby as a `V8::C::Maybe`. If there is a
+     * value present, then run it through the value conversion to get
+     * the most specific subclass of Value:
+     *
+     *   return Value::Maybe(object->Get(cxt, key));
+     */
+    class Maybe : public rr::Maybe {
+    public:
+      Maybe(v8::Isolate* isolate, v8::MaybeLocal<v8::Value> maybe) {
+        if (!maybe.IsEmpty()) {
+          just(Value::handleToRubyObject(isolate, maybe.ToLocalChecked()));
+        }
+      }
+    };
+
     static void Init();
 
     static VALUE IsUndefined(VALUE self);

--- a/lib/v8/c/maybe.rb
+++ b/lib/v8/c/maybe.rb
@@ -1,0 +1,78 @@
+module V8
+  module C
+    ##
+    # Some V8 API methods return a `Maybe` value that force you to check
+    # if the operation failed or not before accessing the underlying
+    # value. This implements the `v8::Maybe` and `v8::MaybeLocal` apis,
+    # and is returned by those low-level C methods:
+    #
+    #   maybe = object.Get(context, key)
+    #   if maybe.IsJust()
+    #     puts maybe.class #=> V8::C::Maybe::Just
+    #     puts "the value is #{maybe.FromJust()}"
+    #   else
+    #     puts maybe.class #=> V8::C::Maybe::Nothing
+    #     puts "operation failed!"
+    #   end
+    #
+    # Note: Instances of `V8::C::Maybe` are only ever created by the C
+    # extension, and should not ever be instantiated from Ruby code.
+    class Maybe
+
+      ##
+      # If true, then this is an instance of `V8::C::Just`, and it does
+      # wrap a value
+      def IsJust()
+        false
+      end
+
+      ##
+      # If true, then this is an instance of `V8::C::Nothing`, and it
+      # does not contain a value. Any attempt to access the value will
+      # raise an error.
+      def IsNothing()
+        false
+      end
+
+      ##
+      # A Maybe that *does* contain a value.
+      class Just < Maybe
+        def initialize(value)
+          @value = value
+        end
+
+        def IsJust()
+          true
+        end
+
+        def FromJust()
+          @value
+        end
+      end
+
+      ##
+      # A Maybe that *does* not contain any value
+      class Nothing < Maybe
+
+        def IsNothing()
+          true
+        end
+
+        def FromJust()
+          fail PendingExceptionError, "no value was available because an exception is pending in this context"
+        end
+      end
+
+      ##
+      # Singleton instance of Nothing.
+      #
+      # We only need one instance of Nothing because there is no
+      # additional state apart from its nothingness.
+      def self.nothing
+        @nothing ||= Nothing.new
+      end
+    end
+
+    class PendingExceptionError < StandardError;end
+  end
+end

--- a/spec/c/array_spec.rb
+++ b/spec/c/array_spec.rb
@@ -9,10 +9,10 @@ describe V8::C::Array do
 
     expect(a.Length).to eq 0
 
-    a.Set(0, o)
+    a.Set(@ctx, 0, o)
     expect(a.Length).to eq 1
 
-    expect(a.Get(0).Equals(o)).to eq true
+    expect(a.Get(@ctx, 0).FromJust().Equals(o)).to eq true
   end
 
   it 'can be initialized with a length' do

--- a/spec/c/function_spec.rb
+++ b/spec/c/function_spec.rb
@@ -24,21 +24,21 @@ describe V8::C::Function do
 
     fn.Call(@ctx.Global, [one, two, 3])
 
-    expect(@ctx.Global.Get(V8::C::String.NewFromUtf8(@isolate, 'one'))).to eq one
-    expect(@ctx.Global.Get(V8::C::String.NewFromUtf8(@isolate, 'two'))).to eq two
-    expect(@ctx.Global.Get(V8::C::String.NewFromUtf8(@isolate, 'three'))).to eq 3
+    expect(@ctx.Global.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'one')).FromJust()).to eq one
+    expect(@ctx.Global.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'two')).FromJust()).to eq two
+    expect(@ctx.Global.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'three')).FromJust()).to eq 3
   end
 
   it 'can be called as a constructor' do
     fn = run '(function() {this.foo = "foo"})'
-    expect(fn.NewInstance.Get(V8::C::String.NewFromUtf8(@isolate, 'foo')).Utf8Value).to eq 'foo'
+    expect(fn.NewInstance.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'foo')).FromJust().Utf8Value).to eq 'foo'
   end
 
   it 'can be called as a constructor with arguments' do
     fn = run '(function(foo) {this.foo = foo})'
     object = fn.NewInstance([V8::C::String.NewFromUtf8(@isolate, 'bar')])
 
-    expect(object.Get(V8::C::String.NewFromUtf8(@isolate, 'foo')).Utf8Value).to eq 'bar'
+    expect(object.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'foo')).FromJust().Utf8Value).to eq 'bar'
   end
 
   # TODO

--- a/spec/c/object_spec.rb
+++ b/spec/c/object_spec.rb
@@ -12,8 +12,13 @@ describe V8::C::Object do
     key = V8::C::String.NewFromUtf8(@isolate, 'foo')
     value = V8::C::String.NewFromUtf8(@isolate, 'bar')
 
-    o.Set(key, value)
-    expect(o.Get(key).Utf8Value).to eq 'bar'
+    maybe = o.Set(@ctx, key, value)
+    expect(maybe.IsJust()).to be true
+    expect(maybe.FromJust()).to be true
+
+    maybe = o.Get(@ctx, key)
+    expect(maybe.IsJust()).to be true
+    expect(maybe.FromJust().Utf8Value).to eq 'bar'
   end
 
   # TODO: Enable this when the methods are implemented in the extension
@@ -52,7 +57,7 @@ describe V8::C::Object do
     one = V8::C::Object.New(@isolate)
     two = V8::C::Object.New(@isolate)
 
-    one.Set(key, two)
-    expect(one.Get(key)).to be two
+    one.Set(@ctx, key, two)
+    expect(one.Get(@ctx, key).FromJust()).to be two
   end
 end

--- a/spec/c/value_spec.rb
+++ b/spec/c/value_spec.rb
@@ -19,7 +19,7 @@ describe V8::C::Value do
     object = V8::C::Object.New(@isolate)
     key = V8::C::String.NewFromUtf8(@isolate, 'key')
 
-    expect(object.Get(key)).to eq nil
+    expect(object.Get(@ctx, key).FromJust()).to eq nil
   end
 
   it 'converts FixNums' do
@@ -33,7 +33,7 @@ describe V8::C::Value do
 
   it 'converts objects' do
     object = V8::C::Object.New(@isolate)
-    object.Set(V8::C::String.NewFromUtf8(@isolate, 'test'), 1)
+    object.Set(@ctx, V8::C::String.NewFromUtf8(@isolate, 'test'), 1)
 
     expect(convert(object)).to eq object
   end

--- a/spec/c_spec_helper.rb
+++ b/spec/c_spec_helper.rb
@@ -1,4 +1,5 @@
 require 'v8/weak'
+require 'v8/c/maybe'
 require 'v8/init'
 
 module V8ContextHelpers


### PR DESCRIPTION
Add support for V8 methods that return `Maybe<T>` and `MaybeLocal<T>`, by performing the check and then generating an appropriate wrapper.

In order to support porting `V8::C::Object#Get()` and `V8::C::Object#Set()` over to the Maybe API, I've added two conversion helper classes, `Bool::Maybe` and `Value::Maybe` for converting `Maybe<bool>` and `MaybeLocal<v8::Value>` respectively. We can add more conversion classes as the need arises.

Of course, It makes the low-level C API just that much more ugly, but they're deprecating the other apis, so it is what it is.

This feels a lot cleaner than the pure C solution in https://github.com/cowboyd/therubyracer/pull/358, so I'll shut that down.