### PR TITLE
normalize value handling

### DIFF
--- a/ext/v8/boolean.h
+++ b/ext/v8/boolean.h
@@ -1,0 +1,40 @@
+// -*- mode: c++ -*-
+
+#ifndef RR_BOOLEAN_H
+#define RR_BOOLEAN_H
+
+namespace rr {
+  class Boolean : public Ref<v8::Boolean> {
+  public:
+    Boolean(v8::Isolate* isolate, v8::Local<v8::Boolean> handle) :
+      Ref<v8::Boolean>(isolate, handle) {}
+    Boolean(VALUE value) : Ref<v8::Boolean>(value) {}
+
+    static void Init() {
+      ClassBuilder("Boolean", Value::Class).
+        defineSingletonMethod("New", &New).
+        defineMethod("Value", &Value).
+        store(&Class);
+    }
+
+    static VALUE New(VALUE self, VALUE r_isolate, VALUE boolean) {
+      Isolate isolate(r_isolate);
+      Locker lock(isolate);
+
+      return Boolean(isolate, v8::Boolean::New(isolate, RTEST(boolean)));
+    }
+
+    static VALUE Value(VALUE self) {
+      Boolean boolean(self);
+      Locker lock(boolean);
+
+      if (boolean->Value()) {
+        return Qtrue;
+      } else {
+        return Qfalse;
+      }
+    }
+  };
+}
+
+#endif /* RR_BOOLEAN_H */

--- a/ext/v8/function-callback.h
+++ b/ext/v8/function-callback.h
@@ -67,7 +67,7 @@ namespace rr {
     static VALUE at(VALUE self, VALUE i) {
       FunctionCallbackInfo info(self);
       Locker lock(info->GetIsolate());
-      return Value::handleToRubyObject(info->GetIsolate(), info[NUM2INT(i)]);
+      return Value(info->GetIsolate(), info[NUM2INT(i)]);
     }
 
     static VALUE Callee(VALUE self) {
@@ -91,7 +91,7 @@ namespace rr {
     static VALUE Data(VALUE self) {
       FunctionCallbackInfo info(self);
       Locker lock(info->GetIsolate());
-      return Value::handleToRubyObject(info->GetIsolate(), info.data);
+      return Value(info->GetIsolate(), info.data);
     }
 
     static VALUE GetIsolate(VALUE self) {

--- a/ext/v8/function.cc
+++ b/ext/v8/function.cc
@@ -60,7 +60,7 @@ namespace rr {
 
     std::vector< v8::Handle<v8::Value> > vector(Value::convertRubyArray(isolate, argv));
 
-    return Value::handleToRubyObject(isolate, function->Call(Value(receiver), RARRAY_LENINT(argv), &vector[0]));
+    return Value(isolate, function->Call(Value(receiver), RARRAY_LENINT(argv), &vector[0]));
   }
 
   VALUE Function::SetName(VALUE self, VALUE name) {
@@ -76,14 +76,14 @@ namespace rr {
     Function function(self);
     Locker lock(function.getIsolate());
 
-    return Value::handleToRubyObject(function.getIsolate(), function->GetName());
+    return Value(function.getIsolate(), function->GetName());
   }
 
   VALUE Function::GetInferredName(VALUE self) {
     Function function(self);
     Locker lock(function.getIsolate());
 
-    return Value::handleToRubyObject(function.getIsolate(), function->GetInferredName());
+    return Value(function.getIsolate(), function->GetInferredName());
   }
 
   VALUE Function::GetScriptLineNumber(VALUE self) {

--- a/ext/v8/init.cc
+++ b/ext/v8/init.cc
@@ -16,6 +16,9 @@ extern "C" {
     Value::Init();
     Object::Init();
     Primitive::Init();
+    Null::Init();
+    Undefined::Init();
+    Boolean::Init();
     Number::Init();
     Integer::Init();
     Name::Init();

--- a/ext/v8/name.h
+++ b/ext/v8/name.h
@@ -9,6 +9,8 @@ namespace rr {
     static VALUE GetIdentityHash(VALUE self);
 
     Name(VALUE self) : Ref<v8::Name>(self) {}
+    Name(v8::Isolate* isolate, v8::Local<v8::Name> name) :
+      Ref<v8::Name>(isolate, name) {}
   };
 }
 

--- a/ext/v8/null.h
+++ b/ext/v8/null.h
@@ -1,0 +1,18 @@
+// -*- mode: c++ -*-
+#ifndef RR_NULL_H
+#define RR_NULL_H
+
+namespace rr {
+  class Null : public Ref<v8::Value> {
+  public:
+    Null(v8::Isolate* isolate, v8::Local<v8::Value> undefined) :
+      Ref<v8::Value>(isolate, undefined) {}
+
+    static inline void Init() {
+      ClassBuilder("Null", Primitive::Class).
+        store(&Class);
+    }
+  };
+}
+
+#endif /* RR_NULL_H */

--- a/ext/v8/rr.h
+++ b/ext/v8/rr.h
@@ -33,9 +33,12 @@ inline VALUE not_implemented(const char* message) {
 #include "context.h"
 
 #include "value.h"
+#include "boolean.h"
 #include "object.h"
 #include "array.h"
 #include "primitive.h"
+#include "undefined.h"
+#include "null.h"
 #include "number.h"
 #include "integer.h"
 

--- a/ext/v8/script.cc
+++ b/ext/v8/script.cc
@@ -37,6 +37,6 @@ namespace rr {
     Context context(rb_context);
     Locker lock(context->GetIsolate());
 
-    return Value::handleToRubyObject(context->GetIsolate(), Script(self)->Run());
+    return Value(context->GetIsolate(), Script(self)->Run());
   }
 }

--- a/ext/v8/symbol.cc
+++ b/ext/v8/symbol.cc
@@ -69,6 +69,6 @@ namespace rr {
     Isolate isolate(symbol.getIsolate());
     Locker lock(isolate);
 
-    return Value::handleToRubyObject(isolate, symbol->Name());
+    return Value(isolate, symbol->Name());
   }
 }

--- a/ext/v8/undefined.h
+++ b/ext/v8/undefined.h
@@ -1,0 +1,18 @@
+// -*- mode: c++ -*-
+#ifndef RR_UNDEFINED_H
+#define RR_UNDEFINED_H
+
+namespace rr {
+  class Undefined : public Ref<v8::Value> {
+  public:
+    Undefined(v8::Isolate* isolate, v8::Local<v8::Value> undefined) :
+      Ref<v8::Value>(isolate, undefined) {}
+
+    static inline void Init() {
+      ClassBuilder("Undefined", Primitive::Class).
+        store(&Class);
+    }
+  };
+}
+
+#endif /* RR_UNDEFINED_H */

--- a/ext/v8/value.cc
+++ b/ext/v8/value.cc
@@ -8,12 +8,12 @@ namespace rr {
       defineMethod("IsNull", &IsNull).
       defineMethod("IsTrue", &IsTrue).
       defineMethod("IsFalse", &IsFalse).
+      defineMethod("IsBoolean", &IsBoolean).
       defineMethod("IsString", &IsString).
       defineMethod("IsFunction", &IsFunction).
       // defineMethod("IsArray", &IsArray).
       defineMethod("IsObject", &IsObject).
-      // defineMethod("IsBoolean", &IsBoolean).
-      // defineMethod("IsNumber", &IsNumber).
+      defineMethod("IsNumber", &IsNumber).
       defineMethod("IsExternal", &IsExternal).
       defineMethod("IsInt32", &IsInt32).
       defineMethod("IsUint32", &IsUint32).
@@ -26,16 +26,13 @@ namespace rr {
       defineMethod("ToString", &ToString).
       // defineMethod("ToDetailString", &ToDetailString).
       // defineMethod("ToObject", &ToObject).
-      // defineMethod("BooleanValue", &BooleanValue).
+      defineMethod("BooleanValue", &BooleanValue).
       // defineMethod("NumberValue", &NumberValue).
       // defineMethod("IntegerValue", &IntegerValue).
       // defineMethod("Uint32Value", &Uint32Value).
       // defineMethod("IntegerValue", &IntegerValue).
       defineMethod("Equals", &Equals).
       defineMethod("StrictEquals", &StrictEquals).
-
-      defineMethod("ToRubyObject", &ToRubyObject).
-      defineSingletonMethod("FromRubyObject", &FromRubyObject).
 
       store(&Class);
   }
@@ -68,6 +65,13 @@ namespace rr {
     return Bool(value->IsFalse());
   }
 
+  VALUE Value::IsBoolean(VALUE self) {
+    Value value(self);
+    Locker lock(value);
+
+    return Bool(value->IsBoolean());
+  }
+
   VALUE Value::IsString(VALUE self) {
     Value value(self);
     Locker lock(value.getIsolate());
@@ -96,6 +100,12 @@ namespace rr {
     return Bool(value->IsExternal());
   }
 
+  VALUE Value::IsNumber(VALUE self) {
+    Value value(self);
+    Locker lock(value);
+    return Bool(value->IsNumber());
+  }
+
   VALUE Value::IsInt32(VALUE self) {
     Value value(self);
     Locker lock(value.getIsolate());
@@ -117,6 +127,13 @@ namespace rr {
     return String(value.getIsolate(), value->ToString());
   }
 
+  VALUE Value::BooleanValue(VALUE self, VALUE r_context) {
+    Value value(self);
+    Locker lock(value);
+
+    return Bool::Maybe(value->BooleanValue(Context(r_context)));
+  }
+
   VALUE Value::Equals(VALUE self, VALUE other) {
     Value value(self);
     Locker lock(value.getIsolate());
@@ -131,31 +148,21 @@ namespace rr {
     return Bool(value->StrictEquals(Value(other)));
   }
 
-  VALUE Value::ToRubyObject(VALUE self) {
-    Value value(self);
-    Locker lock(value.getIsolate());
-
-    return handleToRubyObject(value.getIsolate(), value);
-  }
-
-  VALUE Value::FromRubyObject(VALUE selfClass, VALUE rb_isolate, VALUE value) {
-    Isolate isolate(rb_isolate);
-    Locker lock(isolate);
-
-    return Value(isolate, rubyObjectToHandle(isolate, value));
-  }
-
-  VALUE Value::handleToRubyObject(v8::Isolate* isolate, v8::Handle<v8::Value> handle) {
-    if (handle.IsEmpty() || handle->IsUndefined() || handle->IsNull()) {
+  Value::operator VALUE() {
+    if (handle.IsEmpty()) {
       return Qnil;
     }
 
-    if (handle->IsTrue()) {
-      return Qtrue;
+    if (handle->IsUndefined()) {
+      return Undefined(isolate, handle);
     }
 
-    if (handle->IsFalse()) {
-      return Qfalse;
+    if (handle->IsNull()) {
+      return Null(isolate, handle);
+    }
+
+    if (handle->IsBoolean()) {
+      return Boolean(isolate, handle.As<v8::Boolean>());
     }
 
     if (handle->IsExternal()) {
@@ -174,14 +181,16 @@ namespace rr {
       return Number(isolate, handle);
     }
 
-    if (handle->IsBoolean()) {
-      return handle->BooleanValue() ? Qtrue : Qfalse;
+    if (handle->IsString()) {
+      return String(isolate, handle.As<v8::String>());
     }
 
-    // TODO
+    if (handle->IsSymbol()) {
+      return Symbol(isolate, handle.As<v8::Symbol>());
+    }
 
-    if (handle->IsString()) {
-      return String(isolate, handle->ToString());
+    if (handle->IsName()) {
+      return Name(isolate, handle.As<v8::Name>());
     }
 
     // TODO
@@ -196,8 +205,7 @@ namespace rr {
     if (handle->IsObject()) {
       return Object(isolate, handle->ToObject());
     }
-
-    return Value(isolate, handle);
+    return Ref<v8::Value>::operator VALUE();
   }
 
   v8::Handle<v8::Value> Value::rubyObjectToHandle(v8::Isolate* isolate, VALUE value) {

--- a/ext/v8/value.cc
+++ b/ext/v8/value.cc
@@ -2,14 +2,8 @@
 
 namespace rr {
 
-  VALUE Value::Empty;
-
   void Value::Init() {
-    Empty = rb_eval_string("Object.new");
-
     ClassBuilder("Value").
-      defineConst("Empty", Empty).
-
       defineMethod("IsUndefined", &IsUndefined).
       defineMethod("IsNull", &IsNull).
       defineMethod("IsTrue", &IsTrue).
@@ -44,8 +38,6 @@ namespace rr {
       defineSingletonMethod("FromRubyObject", &FromRubyObject).
 
       store(&Class);
-
-    rb_gc_register_address(&Empty);
   }
 
   VALUE Value::IsUndefined(VALUE self) {
@@ -209,10 +201,6 @@ namespace rr {
   }
 
   v8::Handle<v8::Value> Value::rubyObjectToHandle(v8::Isolate* isolate, VALUE value) {
-    if (rb_equal(value, Empty)) {
-      return v8::Handle<v8::Value>();
-    }
-
     switch (TYPE(value)) {
     case T_FIXNUM:
       return v8::Integer::New(isolate, NUM2INT(value));

--- a/ext/v8/value.h
+++ b/ext/v8/value.h
@@ -18,7 +18,7 @@ namespace rr {
     public:
       Maybe(v8::Isolate* isolate, v8::MaybeLocal<v8::Value> maybe) {
         if (!maybe.IsEmpty()) {
-          just(Value::handleToRubyObject(isolate, maybe.ToLocalChecked()));
+          just(Value(isolate, maybe.ToLocalChecked()));
         }
       }
     };
@@ -34,7 +34,7 @@ namespace rr {
     // static VALUE IsArray(VALUE self);
     static VALUE IsObject(VALUE self);
     static VALUE IsBoolean(VALUE self);
-    // static VALUE IsNumber(VALUE self);
+    static VALUE IsNumber(VALUE self);
     static VALUE IsExternal(VALUE self);
     static VALUE IsInt32(VALUE self);
     static VALUE IsUint32(VALUE self);
@@ -47,7 +47,7 @@ namespace rr {
     static VALUE ToString(VALUE self);
     // static VALUE ToDetailString(VALUE self);
     // static VALUE ToObject(VALUE self);
-    // static VALUE BooleanValue(VALUE self);
+    static VALUE BooleanValue(VALUE self, VALUE context);
     // static VALUE NumberValue(VALUE self);
     // static VALUE IntegerValue(VALUE self);
     // static VALUE Uint32Value(VALUE self);
@@ -62,7 +62,7 @@ namespace rr {
     inline Value(VALUE value) : Ref<v8::Value>(value) {}
     inline Value(v8::Isolate* isolate, v8::Handle<v8::Value> value) : Ref<v8::Value>(isolate, value) {}
 
-    static VALUE handleToRubyObject(v8::Isolate* isolate, v8::Handle<v8::Value> value);
+    operator VALUE();
     static v8::Handle<v8::Value> rubyObjectToHandle(v8::Isolate* isolate, VALUE value);
 
     static std::vector< v8::Handle<v8::Value> > convertRubyArray(v8::Isolate* isolate, VALUE value);

--- a/ext/v8/value.h
+++ b/ext/v8/value.h
@@ -66,8 +66,6 @@ namespace rr {
     static v8::Handle<v8::Value> rubyObjectToHandle(v8::Isolate* isolate, VALUE value);
 
     static std::vector< v8::Handle<v8::Value> > convertRubyArray(v8::Isolate* isolate, VALUE value);
-
-    static VALUE Empty;
   };
 
 }

--- a/spec/c/value_spec.rb
+++ b/spec/c/value_spec.rb
@@ -3,38 +3,46 @@ require 'c_spec_helper'
 describe V8::C::Value do
   requires_v8_context
 
-  def convert(value)
-    V8::C::Value.FromRubyObject(@isolate, value).ToRubyObject
+  describe "Boolean" do
+    let(:t) { V8::C::Boolean::New @isolate, true }
+    let(:f) { V8::C::Boolean::New @isolate, false }
+
+    it "knows true is true, and false is false" do
+      expect(t.IsTrue()).to be true
+      expect(t.IsFalse()).to be false
+      expect(f.IsTrue()).to be false
+      expect(f.IsFalse()).to be true
+      expect(t.IsBoolean()).to be true
+      expect(f.IsBoolean()).to be true
+    end
+
+    it "has a BooleanValue" do
+      expect(t.BooleanValue(@ctx).FromJust()).to be true
+      expect(f.BooleanValue(@ctx).FromJust()).to be false
+    end
   end
 
-  it 'converts strings' do
-    expect(convert('value').Utf8Value).to eq 'value'
+  describe "String" do
+    let(:string) { V8::C::String::NewFromUtf8(@isolate, "value")}
+    it "is a string" do
+       expect(string.IsString()).to be true
+    end
   end
 
-  it 'converts nil' do
-    expect(convert(nil)).to eq nil
+  describe "Number" do
+    let(:int) { V8::C::Integer::New(@isolate, -10) }
+    let(:num) { V8::C::Number::New(@isolate, 5.5) }
+    let(:uint) { V8::C::Integer::NewFromUnsigned(@isolate, 10) }
+
+    it "recognizes integer types" do
+      expect(int.IsNumber).to be true
+      expect(int.IsInt32).to be true
+      expect(int.IsUint32).to be false
+      expect(num.IsNumber()).to be true
+      expect(num.IsInt32).to be false
+      expect(uint.IsNumber).to be true
+      expect(uint.IsUint32).to be true
+    end
   end
 
-  it 'converts undefined to nil' do
-    object = V8::C::Object.New(@isolate)
-    key = V8::C::String.NewFromUtf8(@isolate, 'key')
-
-    expect(object.Get(@ctx, key).FromJust()).to eq nil
-  end
-
-  it 'converts FixNums' do
-    expect(convert(42).Value()).to eq 42
-  end
-
-  it 'converts booleans' do
-    expect(convert(true)).to eq true
-    expect(convert(false)).to eq false
-  end
-
-  it 'converts objects' do
-    object = V8::C::Object.New(@isolate)
-    object.Set(@ctx, V8::C::String.NewFromUtf8(@isolate, 'test'), 1)
-
-    expect(convert(object).StrictEquals(object)).to be true
-  end
 end


### PR DESCRIPTION
This pull requests normalizes value handling in two ways. First, gets rid of the special cases for `Undefined` and `Null` which are actually represented as objects inside v8, so should be represented as objects in our C layer. (we should also add at some point impmente `V8::C::V8::Undefined(@isolate)` and `V8::C::V8::Null(@isolate) ` in order to retreive those values explicitly)

Second, it makes the normal `Value::operator VALUE()` perform the thunk-down on type so that when returning a `v8::Value` to Ruby, there's nothing more to do than use the normal `Value(isolate, handle)` constructor to get the most specific Ruby class.