### PR TITLE
add back the basics of memory testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
   - bundle exec rake compile
   - bundle exec rspec spec/c
   - bundle exec rspec spec/v8/context_spec.rb
+  - bundle exec rspec spec/mem
 sudo: false
 addons:
   apt:

--- a/ext/v8/isolate.cc
+++ b/ext/v8/isolate.cc
@@ -11,7 +11,7 @@ namespace rr {
     ClassBuilder("Isolate").
       defineSingletonMethod("New", &New).
 
-      defineMethod("Dispose", &Isolate::Dispose).
+      defineMethod("IdleNotificationDeadline", &IdleNotificationDeadline).
 
       store(&Class);
   }
@@ -26,7 +26,6 @@ namespace rr {
     create_params.array_buffer_allocator = &data->array_buffer_allocator;
     v8::Isolate* isolate = v8::Isolate::New(create_params);
 
-
     isolate->SetData(0, data);
     isolate->AddGCPrologueCallback(&clearReferences);
 
@@ -34,9 +33,10 @@ namespace rr {
     return Isolate(isolate);
   }
 
-  VALUE Isolate::Dispose(VALUE self) {
+
+  VALUE Isolate::IdleNotificationDeadline(VALUE self, VALUE deadline_in_seconds) {
     Isolate isolate(self);
-    isolate->Dispose();
-    return Qnil;
+    Locker lock(isolate);
+    return Bool(isolate->IdleNotificationDeadline(NUM2DBL(deadline_in_seconds)));
   }
 }

--- a/spec/c/isolate_spec.rb
+++ b/spec/c/isolate_spec.rb
@@ -6,8 +6,4 @@ describe V8::C::Isolate do
   it 'can create a new isolate' do
     expect(isolate).to be
   end
-
-  it "can be disposed of" do
-    isolate.Dispose()
-  end
 end

--- a/spec/c_spec_helper.rb
+++ b/spec/c_spec_helper.rb
@@ -23,8 +23,6 @@ module V8ContextHelpers
         @ctx.Exit
       end
     end
-  ensure
-    @isolate.Dispose()
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,5 @@
 require 'v8'
 
-def run_v8_gc
-  V8::C::V8::LowMemoryNotification()
-  while !V8::C::V8::IdleNotification() do
-  end
-end
-
 def rputs(msg)
   puts "<pre>#{ERB::Util.h(msg)}</pre>"
   $stdout.flush


### PR DESCRIPTION
This adds back the memory tests which ensure The Ruby Racer's
stability. It also includes the changes needed to make these initial
specs pass.

It disallows calling `Dispose()` directly on the underlying
Isolate. If you do, then you could have all of the Ruby objects happily
sitting in memory, but trying to use them would result in a segfault for
trying to use a dead isolate. In order to avoid that, we'd have to put
in safeguards everywhere to make sure for any operation on any context
or object, that it's isolate was still alive.

In order to reduce the complexity of memory management, the safest thing
is to let the garbage collection hook dispose of the isolate
itself. That way there is no doubt that the isolate is no longer in use.