### PR TITLE
Implement Object API

### DIFF
--- a/ext/v8/array.h
+++ b/ext/v8/array.h
@@ -13,6 +13,8 @@ namespace rr {
 
     inline Array(v8::Isolate* isolate, v8::Handle<v8::Array> array) : Ref<v8::Array>(isolate, array) {}
     inline Array(VALUE value) : Ref<v8::Array>(value) {}
+
+    typedef MaybeLocal<Array, v8::Array> Maybe;
   };
 
 }

--- a/ext/v8/enum.h
+++ b/ext/v8/enum.h
@@ -16,6 +16,15 @@ namespace rr {
     operator T() {
       return RTEST(value) ? (T)NUM2INT(value) : defaultValue;
     }
+
+    class Maybe : public rr::Maybe {
+    public:
+      Maybe(v8::Maybe<T> maybe) {
+        if (maybe.IsJust()) {
+          just(INT2FIX((int)maybe.FromJust()));
+        }
+      }
+    };
   };
 
   inline void DefineEnums() {

--- a/ext/v8/object.cc
+++ b/ext/v8/object.cc
@@ -21,6 +21,28 @@ namespace rr {
       defineMethod("GetPrototype", &GetPrototype).
       defineMethod("SetPrototype", &SetPrototype).
       defineMethod("ObjectProtoToString", &ObjectProtoToString).
+      defineMethod("GetConstructorName", &GetConstructorName).
+      defineMethod("InternalFieldCount", &InternalFieldCount).
+      defineMethod("GetInternalField", &GetInternalField).
+      defineMethod("SetInternalField", &SetInternalField).
+      defineMethod("HasOwnProperty", &HasOwnProperty).
+      defineMethod("HasRealNamedProperty", &HasRealNamedProperty).
+      defineMethod("HasRealIndexedProperty", &HasRealIndexedProperty).
+      defineMethod("HasRealNamedCallbackProperty", &HasRealNamedCallbackProperty).
+      defineMethod("GetRealNamedPropertyInPrototypeChain", &GetRealNamedPropertyInPrototypeChain).
+      defineMethod("GetRealNamedProperty", &GetRealNamedProperty).
+      defineMethod("GetRealNamedPropertyAttributes", &GetRealNamedPropertyAttributes).
+      defineMethod("GetRealNamedPropertyAttributesInPrototypeChain", &GetRealNamedPropertyAttributesInPrototypeChain).
+      defineMethod("HasNamedLookupInterceptor", &HasNamedLookupInterceptor).
+      defineMethod("HasIndexedLookupInterceptor", &HasIndexedLookupInterceptor).
+      defineMethod("SetHiddenValue", &SetHiddenValue).
+      defineMethod("GetHiddenValue", &GetHiddenValue).
+      defineMethod("DeleteHiddenValue", &DeleteHiddenValue).
+      defineMethod("Clone", &Clone).
+      defineMethod("CreationContext", &CreationContext).
+      defineMethod("IsCallable", &IsCallable).
+      defineMethod("CallAsFunction", &CallAsFunction).
+      defineMethod("CallAsConstructor", &CallAsConstructor).
 
       store(&Class);
   }
@@ -208,6 +230,192 @@ namespace rr {
     Locker lock(object);
 
     return String::Maybe(object.getIsolate(), object->ObjectProtoToString(Context(r_context)));
+  }
+
+  VALUE Object::GetConstructorName(VALUE self) {
+    Object object(self);
+    Locker lock(object);
+
+    return String(object.getIsolate(), object->GetConstructorName());
+  }
+
+  VALUE Object::InternalFieldCount(VALUE self) {
+    Object object(self);
+    Locker lock(object);
+
+    return INT2FIX(object->InternalFieldCount());
+  }
+
+  VALUE Object::GetInternalField(VALUE self, VALUE index) {
+    Object object(self);
+    Locker lock(object);
+
+    return Value(object.getIsolate(), object->GetInternalField(NUM2INT(index)));
+  }
+
+  VALUE Object::SetInternalField(VALUE self, VALUE index, VALUE value) {
+    Object object(self);
+    Locker lock(object);
+
+    object->SetInternalField(NUM2INT(index), *Value(value));
+
+    return Qnil;
+  }
+
+  VALUE Object::HasOwnProperty(VALUE self, VALUE r_context, VALUE key) {
+    Object object(self);
+    Locker lock(object);
+
+    return Bool::Maybe(object->HasOwnProperty(Context(r_context), *Name(key)));
+  }
+
+  VALUE Object::HasRealNamedProperty(VALUE self, VALUE r_context, VALUE key) {
+    Object object(self);
+    Locker lock(object);
+
+    return Bool::Maybe(object->HasRealNamedProperty(Context(r_context), *Name(key)));
+  }
+
+  VALUE Object::HasRealIndexedProperty(VALUE self, VALUE r_context, VALUE index) {
+    Object object(self);
+    Locker lock(object);
+
+    return Bool::Maybe(object->HasRealIndexedProperty(Context(r_context), NUM2INT(index)));
+  }
+
+  VALUE Object::HasRealNamedCallbackProperty(VALUE self, VALUE r_context, VALUE key) {
+    Object object(self);
+    Locker lock(object);
+
+    return Bool::Maybe(object->HasRealNamedCallbackProperty(Context(r_context), *Name(key)));
+  }
+
+  VALUE Object::GetRealNamedPropertyInPrototypeChain(VALUE self, VALUE r_context, VALUE key) {
+    Object object(self);
+    Locker lock(object);
+
+    return Value::Maybe(object.getIsolate(), object->GetRealNamedPropertyInPrototypeChain(
+      Context(r_context),
+      *Name(key)
+    ));
+  }
+
+  VALUE Object::GetRealNamedProperty(VALUE self, VALUE r_context, VALUE key) {
+    Object object(self);
+    Locker lock(object);
+
+    return Value::Maybe(object.getIsolate(), object->GetRealNamedProperty(
+      Context(r_context),
+      *Name(key)
+    ));
+  }
+
+  VALUE Object::GetRealNamedPropertyAttributes(VALUE self, VALUE r_context, VALUE key) {
+    Object object(self);
+    Locker lock(object);
+
+    return Enum<v8::PropertyAttribute>::Maybe(object->GetRealNamedPropertyAttributes(
+      Context(r_context),
+      *Name(key)
+    ));
+  }
+
+  VALUE Object::GetRealNamedPropertyAttributesInPrototypeChain(VALUE self, VALUE r_context, VALUE key) {
+    Object object(self);
+    Locker lock(object);
+
+    return Enum<v8::PropertyAttribute>::Maybe(object->GetRealNamedPropertyAttributesInPrototypeChain(
+      Context(r_context),
+      *Name(key)
+    ));
+  }
+
+  VALUE Object::HasNamedLookupInterceptor(VALUE self) {
+    Object object(self);
+    Locker lock(object);
+
+    return Bool(object->HasNamedLookupInterceptor());
+  }
+
+  VALUE Object::HasIndexedLookupInterceptor(VALUE self) {
+    Object object(self);
+    Locker lock(object);
+
+    return Bool(object->HasIndexedLookupInterceptor());
+  }
+
+  VALUE Object::SetHiddenValue(VALUE self, VALUE key, VALUE value) {
+    Object object(self);
+    Locker lock(object);
+
+    return Bool(object->SetHiddenValue(String(key), Value(value)));
+  }
+
+  VALUE Object::GetHiddenValue(VALUE self, VALUE key) {
+    Object object(self);
+    Locker lock(object);
+
+    return Value(object.getIsolate(), object->GetHiddenValue(String(key)));
+  }
+
+  VALUE Object::DeleteHiddenValue(VALUE self, VALUE key) {
+    Object object(self);
+    Locker lock(object);
+
+    return Bool(object->DeleteHiddenValue(String(key)));
+  }
+
+  VALUE Object::Clone(VALUE self) {
+    Object object(self);
+    Locker lock(object);
+
+    return Object(object.getIsolate(), object->Clone());
+  }
+
+  VALUE Object::CreationContext(VALUE self) {
+    Object object(self);
+    Locker lock(object);
+
+    return Context(object->CreationContext());
+  }
+
+  VALUE Object::IsCallable(VALUE self) {
+    Object object(self);
+    Locker lock(object);
+
+    return Bool(object->IsCallable());
+  }
+
+  VALUE Object::CallAsFunction(int argc, VALUE* argv, VALUE self) {
+    VALUE r_context, recv, r_argv;
+    rb_scan_args(argc, argv, "30", &r_context, &recv, &r_argv);
+
+    Object object(self);
+    v8::Isolate* isolate = object.getIsolate();
+    Locker lock(isolate);
+
+    std::vector< v8::Handle<v8::Value> > vector(Value::convertRubyArray(isolate, r_argv));
+
+    return Value::Maybe(isolate, object->CallAsFunction(
+      Context(r_context),
+      Value(recv),
+      RARRAY_LENINT(r_argv),
+      &vector[0]
+    ));
+  }
+
+  VALUE Object::CallAsConstructor(VALUE self, VALUE r_context, VALUE argv) {
+    Object object(self);
+    v8::Isolate* isolate = object.getIsolate();
+    Locker lock(isolate);
+
+    std::vector< v8::Handle<v8::Value> > vector(Value::convertRubyArray(isolate, argv));
+
+    return Value::Maybe(isolate, object->CallAsConstructor(
+      Context(r_context),
+      RARRAY_LENINT(argv),
+      &vector[0]
+    ));
   }
 
   Object::operator VALUE() {

--- a/ext/v8/object.cc
+++ b/ext/v8/object.cc
@@ -13,6 +13,7 @@ namespace rr {
       defineMethod("SetAccessor", &SetAccessor).
       defineMethod("CreateDataProperty", &CreateDataProperty).
       defineMethod("DefineOwnProperty", &DefineOwnProperty).
+      defineMethod("GetPropertyAttributes", &GetPropertyAttributes).
 
       store(&Class);
   }
@@ -123,6 +124,16 @@ namespace rr {
       *Name(key),
       Value(value),
       Enum<v8::PropertyAttribute>(attribute, v8::None)
+    ));
+  }
+
+  VALUE Object::GetPropertyAttributes(VALUE self, VALUE r_context, VALUE key) {
+    Object object(self);
+    Locker lock(object);
+
+    return Enum<v8::PropertyAttribute>::Maybe(object->GetPropertyAttributes(
+      Context(r_context),
+      *Name(key)
     ));
   }
 

--- a/ext/v8/object.cc
+++ b/ext/v8/object.cc
@@ -20,6 +20,7 @@ namespace rr {
       defineMethod("GetOwnPropertyNames", &GetOwnPropertyNames).
       defineMethod("GetPrototype", &GetPrototype).
       defineMethod("SetPrototype", &SetPrototype).
+      defineMethod("ObjectProtoToString", &ObjectProtoToString).
 
       store(&Class);
   }
@@ -200,6 +201,13 @@ namespace rr {
       Context(r_context),
       *Value(prototype)
     ));
+  }
+
+  VALUE Object::ObjectProtoToString(VALUE self, VALUE r_context) {
+    Object object(self);
+    Locker lock(object);
+
+    return String::Maybe(object.getIsolate(), object->ObjectProtoToString(Context(r_context)));
   }
 
   Object::operator VALUE() {

--- a/ext/v8/object.cc
+++ b/ext/v8/object.cc
@@ -18,6 +18,8 @@ namespace rr {
       defineMethod("GetOwnPropertyDescriptor", &GetOwnPropertyDescriptor).
       defineMethod("GetPropertyNames", &GetPropertyNames).
       defineMethod("GetOwnPropertyNames", &GetOwnPropertyNames).
+      defineMethod("GetPrototype", &GetPrototype).
+      defineMethod("SetPrototype", &SetPrototype).
 
       store(&Class);
   }
@@ -181,6 +183,23 @@ namespace rr {
     Locker lock(object);
 
     return Array::Maybe(object.getIsolate(), object->GetOwnPropertyNames(Context(r_context)));
+  }
+
+  VALUE Object::GetPrototype(VALUE self) {
+    Object object(self);
+    Locker lock(object);
+
+    return Value(object.getIsolate(), object->GetPrototype());
+  }
+
+  VALUE Object::SetPrototype(VALUE self, VALUE r_context, VALUE prototype) {
+    Object object(self);
+    Locker lock(object);
+
+    return Bool::Maybe(object->SetPrototype(
+      Context(r_context),
+      *Value(prototype)
+    ));
   }
 
   Object::operator VALUE() {

--- a/ext/v8/object.cc
+++ b/ext/v8/object.cc
@@ -16,6 +16,8 @@ namespace rr {
       defineMethod("DefineOwnProperty", &DefineOwnProperty).
       defineMethod("GetPropertyAttributes", &GetPropertyAttributes).
       defineMethod("GetOwnPropertyDescriptor", &GetOwnPropertyDescriptor).
+      defineMethod("GetPropertyNames", &GetPropertyNames).
+      defineMethod("GetOwnPropertyNames", &GetOwnPropertyNames).
 
       store(&Class);
   }
@@ -165,6 +167,20 @@ namespace rr {
       Context(r_context),
       *rr::String(key)
     ));
+  }
+
+  VALUE Object::GetPropertyNames(VALUE self, VALUE r_context) {
+    Object object(self);
+    Locker lock(object);
+
+    return Array::Maybe(object.getIsolate(), object->GetPropertyNames(Context(r_context)));
+  }
+
+  VALUE Object::GetOwnPropertyNames(VALUE self, VALUE r_context) {
+    Object object(self);
+    Locker lock(object);
+
+    return Array::Maybe(object.getIsolate(), object->GetOwnPropertyNames(Context(r_context)));
   }
 
   Object::operator VALUE() {

--- a/ext/v8/object.cc
+++ b/ext/v8/object.cc
@@ -12,6 +12,7 @@ namespace rr {
       defineMethod("Delete", &Delete).
       defineMethod("SetAccessor", &SetAccessor).
       defineMethod("CreateDataProperty", &CreateDataProperty).
+      defineMethod("DefineOwnProperty", &DefineOwnProperty).
 
       store(&Class);
   }
@@ -108,6 +109,21 @@ namespace rr {
     } else {
       return Bool::Maybe(object->CreateDataProperty(Context(r_context), *Name(key), Value(value)));
     }
+  }
+
+  VALUE Object::DefineOwnProperty(int argc, VALUE* argv, VALUE self) {
+    VALUE r_context, key, value, attribute;
+    rb_scan_args(argc, argv, "31", &r_context, &key, &value, &attribute);
+
+    Object object(self);
+    Locker lock(object);
+
+    return Bool::Maybe(object->DefineOwnProperty(
+      Context(r_context),
+      *Name(key),
+      Value(value),
+      Enum<v8::PropertyAttribute>(attribute, v8::None)
+    ));
   }
 
   Object::operator VALUE() {

--- a/ext/v8/object.cc
+++ b/ext/v8/object.cc
@@ -11,6 +11,7 @@ namespace rr {
       defineMethod("Has", &Has).
       defineMethod("Delete", &Delete).
       defineMethod("SetAccessor", &SetAccessor).
+      defineMethod("SetAccessorProperty", &SetAccessorProperty).
       defineMethod("CreateDataProperty", &CreateDataProperty).
       defineMethod("DefineOwnProperty", &DefineOwnProperty).
       defineMethod("GetPropertyAttributes", &GetPropertyAttributes).
@@ -100,6 +101,24 @@ namespace rr {
       Enum<v8::AccessControl>(settings, v8::DEFAULT),
       Enum<v8::PropertyAttribute>(attribute, v8::None)
     ));
+  }
+
+  VALUE Object::SetAccessorProperty(int argc, VALUE* argv, VALUE self) {
+    VALUE r_context, name, getter, setter, attribute, settings;
+    rb_scan_args(argc, argv, "33", &r_context, &name, &getter, &setter, &attribute, &settings);
+
+    Object object(self);
+    Locker lock(object);
+
+    object->SetAccessorProperty(
+      Name(name),
+      *Function(getter),
+      RTEST(setter) ? *Function(setter) : v8::Local<v8::Function>(),
+      Enum<v8::PropertyAttribute>(attribute, v8::None),
+      Enum<v8::AccessControl>(settings, v8::DEFAULT)
+    );
+
+    return Qnil;
   }
 
   VALUE Object::CreateDataProperty(VALUE self, VALUE r_context, VALUE key, VALUE value) {

--- a/ext/v8/object.cc
+++ b/ext/v8/object.cc
@@ -14,6 +14,7 @@ namespace rr {
       defineMethod("CreateDataProperty", &CreateDataProperty).
       defineMethod("DefineOwnProperty", &DefineOwnProperty).
       defineMethod("GetPropertyAttributes", &GetPropertyAttributes).
+      defineMethod("GetOwnPropertyDescriptor", &GetOwnPropertyDescriptor).
 
       store(&Class);
   }
@@ -134,6 +135,16 @@ namespace rr {
     return Enum<v8::PropertyAttribute>::Maybe(object->GetPropertyAttributes(
       Context(r_context),
       *Name(key)
+    ));
+  }
+
+  VALUE Object::GetOwnPropertyDescriptor(VALUE self, VALUE r_context, VALUE key) {
+    Object object(self);
+    Locker lock(object);
+
+    return Value::Maybe(object.getIsolate(), object->GetOwnPropertyDescriptor(
+      Context(r_context),
+      *rr::String(key)
     ));
   }
 

--- a/ext/v8/object.cc
+++ b/ext/v8/object.cc
@@ -11,6 +11,7 @@ namespace rr {
       defineMethod("Has", &Has).
       defineMethod("Delete", &Delete).
       defineMethod("SetAccessor", &SetAccessor).
+      defineMethod("CreateDataProperty", &CreateDataProperty).
 
       store(&Class);
   }
@@ -96,6 +97,17 @@ namespace rr {
       Enum<v8::AccessControl>(settings, v8::DEFAULT),
       Enum<v8::PropertyAttribute>(attribute, v8::None)
     ));
+  }
+
+  VALUE Object::CreateDataProperty(VALUE self, VALUE r_context, VALUE key, VALUE value) {
+    Object object(self);
+    Locker lock(object);
+
+    if (rb_obj_is_kind_of(key, rb_cNumeric)) {
+      return Bool::Maybe(object->CreateDataProperty(Context(r_context), Uint32_t(key), Value(value)));
+    } else {
+      return Bool::Maybe(object->CreateDataProperty(Context(r_context), *Name(key), Value(value)));
+    }
   }
 
   Object::operator VALUE() {

--- a/ext/v8/object.h
+++ b/ext/v8/object.h
@@ -16,6 +16,7 @@ namespace rr {
     static VALUE SetAccessor(int argc, VALUE* argv, VALUE self);
 
     static VALUE CreateDataProperty(VALUE self, VALUE r_context, VALUE key, VALUE value);
+    static VALUE DefineOwnProperty(int argc, VALUE* argv, VALUE self);
 
     inline Object(VALUE value) : Ref<v8::Object>(value) {}
     inline Object(v8::Isolate* isolate, v8::Handle<v8::Object> object) : Ref<v8::Object>(isolate, object) {}

--- a/ext/v8/object.h
+++ b/ext/v8/object.h
@@ -27,6 +27,35 @@ namespace rr {
     static VALUE SetPrototype(VALUE self, VALUE r_context, VALUE prototype);
 
     static VALUE ObjectProtoToString(VALUE self, VALUE r_context);
+    static VALUE GetConstructorName(VALUE self);
+
+    static VALUE InternalFieldCount(VALUE self);
+    static VALUE GetInternalField(VALUE self, VALUE index);
+    static VALUE SetInternalField(VALUE self, VALUE index, VALUE value);
+
+    static VALUE HasOwnProperty(VALUE self, VALUE r_context, VALUE key);
+    static VALUE HasRealNamedProperty(VALUE self, VALUE r_context, VALUE key);
+    static VALUE HasRealIndexedProperty(VALUE self, VALUE r_context, VALUE index);
+    static VALUE HasRealNamedCallbackProperty(VALUE self, VALUE r_context, VALUE key);
+    static VALUE GetRealNamedPropertyInPrototypeChain(VALUE self, VALUE r_context, VALUE key);
+    static VALUE GetRealNamedProperty(VALUE self, VALUE r_context, VALUE key);
+    static VALUE GetRealNamedPropertyAttributes(VALUE self, VALUE r_context, VALUE key);
+    static VALUE GetRealNamedPropertyAttributesInPrototypeChain(VALUE self, VALUE r_context, VALUE key);
+
+    static VALUE HasNamedLookupInterceptor(VALUE self);
+    static VALUE HasIndexedLookupInterceptor(VALUE self);
+
+    static VALUE SetHiddenValue(VALUE self, VALUE key, VALUE value);
+    static VALUE GetHiddenValue(VALUE self, VALUE key);
+    static VALUE DeleteHiddenValue(VALUE self, VALUE key);
+
+    static VALUE Clone(VALUE self);
+    static VALUE CreationContext(VALUE self);
+
+    static VALUE IsCallable(VALUE self);
+
+    static VALUE CallAsFunction(int argc, VALUE* argv, VALUE self);
+    static VALUE CallAsConstructor(VALUE self, VALUE r_context, VALUE argv);
 
     inline Object(VALUE value) : Ref<v8::Object>(value) {}
     inline Object(v8::Isolate* isolate, v8::Handle<v8::Object> object) : Ref<v8::Object>(isolate, object) {}

--- a/ext/v8/object.h
+++ b/ext/v8/object.h
@@ -18,6 +18,7 @@ namespace rr {
     static VALUE CreateDataProperty(VALUE self, VALUE r_context, VALUE key, VALUE value);
     static VALUE DefineOwnProperty(int argc, VALUE* argv, VALUE self);
     static VALUE GetPropertyAttributes(VALUE self, VALUE r_context, VALUE key);
+    static VALUE GetOwnPropertyDescriptor(VALUE self, VALUE r_context, VALUE key);
 
     inline Object(VALUE value) : Ref<v8::Object>(value) {}
     inline Object(v8::Isolate* isolate, v8::Handle<v8::Object> object) : Ref<v8::Object>(isolate, object) {}

--- a/ext/v8/object.h
+++ b/ext/v8/object.h
@@ -26,6 +26,8 @@ namespace rr {
     static VALUE GetPrototype(VALUE self);
     static VALUE SetPrototype(VALUE self, VALUE r_context, VALUE prototype);
 
+    static VALUE ObjectProtoToString(VALUE self, VALUE r_context);
+
     inline Object(VALUE value) : Ref<v8::Object>(value) {}
     inline Object(v8::Isolate* isolate, v8::Handle<v8::Object> object) : Ref<v8::Object>(isolate, object) {}
 

--- a/ext/v8/object.h
+++ b/ext/v8/object.h
@@ -21,6 +21,8 @@ namespace rr {
     static VALUE DefineOwnProperty(int argc, VALUE* argv, VALUE self);
     static VALUE GetPropertyAttributes(VALUE self, VALUE r_context, VALUE key);
     static VALUE GetOwnPropertyDescriptor(VALUE self, VALUE r_context, VALUE key);
+    static VALUE GetPropertyNames(VALUE self, VALUE r_context);
+    static VALUE GetOwnPropertyNames(VALUE self, VALUE r_context);
 
     inline Object(VALUE value) : Ref<v8::Object>(value) {}
     inline Object(v8::Isolate* isolate, v8::Handle<v8::Object> object) : Ref<v8::Object>(isolate, object) {}

--- a/ext/v8/object.h
+++ b/ext/v8/object.h
@@ -15,6 +15,8 @@ namespace rr {
     static VALUE Delete(VALUE self, VALUE r_context, VALUE key);
     static VALUE SetAccessor(int argc, VALUE* argv, VALUE self);
 
+    static VALUE CreateDataProperty(VALUE self, VALUE r_context, VALUE key, VALUE value);
+
     inline Object(VALUE value) : Ref<v8::Object>(value) {}
     inline Object(v8::Isolate* isolate, v8::Handle<v8::Object> object) : Ref<v8::Object>(isolate, object) {}
 

--- a/ext/v8/object.h
+++ b/ext/v8/object.h
@@ -17,6 +17,7 @@ namespace rr {
 
     static VALUE CreateDataProperty(VALUE self, VALUE r_context, VALUE key, VALUE value);
     static VALUE DefineOwnProperty(int argc, VALUE* argv, VALUE self);
+    static VALUE GetPropertyAttributes(VALUE self, VALUE r_context, VALUE key);
 
     inline Object(VALUE value) : Ref<v8::Object>(value) {}
     inline Object(v8::Isolate* isolate, v8::Handle<v8::Object> object) : Ref<v8::Object>(isolate, object) {}

--- a/ext/v8/object.h
+++ b/ext/v8/object.h
@@ -13,7 +13,9 @@ namespace rr {
     static VALUE GetIdentityHash(VALUE self);
     static VALUE Has(VALUE self, VALUE r_context, VALUE key);
     static VALUE Delete(VALUE self, VALUE r_context, VALUE key);
+
     static VALUE SetAccessor(int argc, VALUE* argv, VALUE self);
+    static VALUE SetAccessorProperty(int argc, VALUE* argv, VALUE self);
 
     static VALUE CreateDataProperty(VALUE self, VALUE r_context, VALUE key, VALUE value);
     static VALUE DefineOwnProperty(int argc, VALUE* argv, VALUE self);

--- a/ext/v8/object.h
+++ b/ext/v8/object.h
@@ -23,6 +23,8 @@ namespace rr {
     static VALUE GetOwnPropertyDescriptor(VALUE self, VALUE r_context, VALUE key);
     static VALUE GetPropertyNames(VALUE self, VALUE r_context);
     static VALUE GetOwnPropertyNames(VALUE self, VALUE r_context);
+    static VALUE GetPrototype(VALUE self);
+    static VALUE SetPrototype(VALUE self, VALUE r_context, VALUE prototype);
 
     inline Object(VALUE value) : Ref<v8::Object>(value) {}
     inline Object(v8::Isolate* isolate, v8::Handle<v8::Object> object) : Ref<v8::Object>(isolate, object) {}

--- a/ext/v8/rr.h
+++ b/ext/v8/rr.h
@@ -17,9 +17,10 @@ inline VALUE not_implemented(const char* message) {
 }
 
 #include "class_builder.h"
-#include "enum.h"
 
 #include "maybe.h"
+#include "enum.h"
+
 #include "equiv.h"
 #include "bool.h"
 #include "uint32_t.h"

--- a/ext/v8/rr_string.h
+++ b/ext/v8/rr_string.h
@@ -15,6 +15,8 @@ namespace rr {
     inline String(v8::Isolate* isolate, v8::Handle<v8::String> string) : Ref<v8::String>(isolate, string) {}
 
     virtual operator v8::Handle<v8::String>() const;
+
+    typedef MaybeLocal<rr::String, v8::String> Maybe;
   };
 
 }

--- a/spec/c/array_spec.rb
+++ b/spec/c/array_spec.rb
@@ -12,7 +12,7 @@ describe V8::C::Array do
     a.Set(@ctx, 0, o)
     expect(a.Length).to eq 1
 
-    expect(a.Get(@ctx, 0).FromJust().Equals(o)).to eq true
+    expect(a.Get(@ctx, 0)).to v8_eq o
   end
 
   it 'can be initialized with a length' do

--- a/spec/c/function_spec.rb
+++ b/spec/c/function_spec.rb
@@ -63,8 +63,8 @@ describe V8::C::Function do
     end
 
     let(:data) { V8::C::Object::New(@isolate) }
-    let(:callback) { FunctionCallback.new @isolate}
-    let(:fn) { V8::C::Function::New(@isolate, callback, data)}
+    let(:callback) { FunctionCallback.new @isolate }
+    let(:fn) { V8::C::Function::New(@isolate, callback, data) }
 
     before do
       expect(fn.Call(@ctx.Global(), ["world"]).Utf8Value()).to eql "ohai world"

--- a/spec/c/function_spec.rb
+++ b/spec/c/function_spec.rb
@@ -24,8 +24,8 @@ describe V8::C::Function do
 
     fn.Call(@ctx.Global, [one, two, 3])
 
-    expect(@ctx.Global.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'one')).FromJust().StrictEquals(one)).to be true
-    expect(@ctx.Global.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'two')).FromJust().StrictEquals(two)).to be true
+    expect(@ctx.Global.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'one'))).to strict_eq one
+    expect(@ctx.Global.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'two'))).to strict_eq two
     expect(@ctx.Global.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'three')).FromJust().Value()).to eq 3
   end
 
@@ -77,7 +77,7 @@ describe V8::C::Function do
       expect(callback.this.GetIdentityHash()).to eql @ctx.Global().GetIdentityHash()
       expect(callback.is_construct_call).to be false
       expect(callback.data).not_to be_nil
-      expect(callback.data.StrictEquals(data)).to be true
+      expect(callback.data).to strict_eq data
     end
   end
 

--- a/spec/c/object_spec.rb
+++ b/spec/c/object_spec.rb
@@ -214,6 +214,42 @@ describe V8::C::Object do
     end
   end
 
+  describe '#GetPropertyNames' do
+    it 'can get array of attribute names' do
+      o = V8::C::Object.New(@isolate)
+      key_one = V8::C::String.NewFromUtf8(@isolate, 'foo 1')
+      key_two = V8::C::String.NewFromUtf8(@isolate, 'foo 2')
+      data = V8::C::String.NewFromUtf8(@isolate, 'data')
+
+      expect(o.DefineOwnProperty(@ctx, key_one, data)).to be_successful
+      expect(o.DefineOwnProperty(@ctx, key_two, data)).to be_successful
+
+      names = o.GetPropertyNames(@ctx)
+      expect(names).to be_successful
+
+      expect(names.FromJust.Get(@ctx, 0)).to v8_eq key_one
+      expect(names.FromJust.Get(@ctx, 1)).to v8_eq key_two
+    end
+  end
+
+  describe '#GetOwnPropertyNames' do
+    it 'can get array of attribute names' do
+      o = V8::C::Object.New(@isolate)
+      key_one = V8::C::String.NewFromUtf8(@isolate, 'foo 1')
+      key_two = V8::C::String.NewFromUtf8(@isolate, 'foo 2')
+      data = V8::C::String.NewFromUtf8(@isolate, 'data')
+
+      expect(o.DefineOwnProperty(@ctx, key_one, data)).to be_successful
+      expect(o.DefineOwnProperty(@ctx, key_two, data)).to be_successful
+
+      names = o.GetOwnPropertyNames(@ctx)
+      expect(names).to be_successful
+
+      expect(names.FromJust.Get(@ctx, 0)).to v8_eq key_one
+      expect(names.FromJust.Get(@ctx, 1)).to v8_eq key_two
+    end
+  end
+
   # TODO: Enable this when the methods are implemented in the extension
   # it 'can retrieve all property names' do
   #   o = V8::C::Object.New

--- a/spec/c/object_spec.rb
+++ b/spec/c/object_spec.rb
@@ -12,39 +12,25 @@ describe V8::C::Object do
     key = V8::C::String.NewFromUtf8(@isolate, 'foo')
     value = V8::C::String.NewFromUtf8(@isolate, 'bar')
 
-    maybe = o.Set(@ctx, key, value)
-    expect(maybe.IsJust()).to be true
-    expect(maybe.FromJust()).to be true
-
-    maybe = o.Get(@ctx, key)
-    expect(maybe.IsJust()).to be true
-    expect(maybe.FromJust().Utf8Value).to eq 'bar'
+    expect(o.Set(@ctx, key, value)).to be_successful
+    expect(o.Get(@ctx, key)).to strict_eq value
   end
 
   it 'can determine if a key has been set' do
     o = V8::C::Object.New(@isolate)
     key = V8::C::String.NewFromUtf8(@isolate, 'foo')
 
-    o.Set(@ctx, key, key)
-
-    maybe = o.Has(@ctx, key)
-    expect(maybe.IsJust()).to be true
-    expect(maybe.FromJust()).to eq true
+    expect(o.Set(@ctx, key, key)).to be_successful
+    expect(o.Has(@ctx, key)).to be_successful
   end
 
   it 'can delete keys' do
     o = V8::C::Object.New(@isolate)
     key = V8::C::String.NewFromUtf8(@isolate, 'foo')
 
-    o.Set(@ctx, key, key)
-
-    maybe = o.Delete(@ctx, key)
-    expect(maybe.IsJust()).to be true
-    expect(maybe.FromJust()).to eq true
-
-    maybe = o.Has(@ctx, key)
-    expect(maybe.IsJust()).to be true
-    expect(maybe.FromJust()).to eq false
+    expect(o.Set(@ctx, key, key)).to be_successful
+    expect(o.Delete(@ctx, key)).to be_successful
+    expect(o.Has(@ctx, key)).to eq_just false
   end
 
   describe '#SetAccessor' do
@@ -65,14 +51,11 @@ describe V8::C::Object do
         info.GetReturnValue.Set(get_value)
       end
 
-      o.SetAccessor(@ctx, key, getter, nil, data)
+      expect(o.SetAccessor(@ctx, key, getter, nil, data)).to be_successful
+      expect(o.Get(@ctx, key)).to strict_eq get_value
 
-      maybe = o.Get(@ctx, key)
-      expect(maybe.IsJust).to be true
-      expect(maybe.FromJust.StrictEquals(get_value)).to be true
-
-      expect(get_name.Equals(key)).to be true
-      expect(get_data.StrictEquals(data)).to be true
+      expect(get_name).to v8_eq key
+      expect(get_data).to strict_eq data
     end
 
     it 'can set setters' do
@@ -89,14 +72,12 @@ describe V8::C::Object do
         set_value = value
       end
 
-      o.SetAccessor(@ctx, key, proc { }, setter, data)
+      expect(o.SetAccessor(@ctx, key, proc { }, setter, data)).to be_successful
 
-      maybe = o.Set(@ctx, key, data)
-      expect(maybe.IsJust).to be true
-      expect(maybe.FromJust).to be true
+      expect(o.Set(@ctx, key, data)).to be_successful
 
-      expect(set_data.StrictEquals(data)).to be true
-      expect(set_value.StrictEquals(data)).to be true
+      expect(set_data).to strict_eq data
+      expect(set_value).to strict_eq data
     end
   end
 

--- a/spec/c/object_spec.rb
+++ b/spec/c/object_spec.rb
@@ -103,6 +103,17 @@ describe V8::C::Object do
     end
   end
 
+  describe '#GetPropertyAttributes' do
+    it 'can get the set attributes' do
+      o = V8::C::Object.New(@isolate)
+      key = V8::C::String.NewFromUtf8(@isolate, 'foo')
+      data = V8::C::String.NewFromUtf8(@isolate, 'data')
+
+      expect(o.DefineOwnProperty(@ctx, key, data, V8::C::PropertyAttribute::DontEnum)).to be_successful
+      expect(o.GetPropertyAttributes(@ctx, key)).to eq_just V8::C::PropertyAttribute::DontEnum
+    end
+  end
+
   # TODO: Enable this when the methods are implemented in the extension
   # it 'can retrieve all property names' do
   #   o = V8::C::Object.New

--- a/spec/c/object_spec.rb
+++ b/spec/c/object_spec.rb
@@ -282,4 +282,24 @@ describe V8::C::Object do
       expect(names.FromJust.Get(@ctx, 1)).to v8_eq prototype_key
     end
   end
+
+  describe '#ObjectProtoToString' do
+    it 'can return a string representation of simple objects' do
+      o = V8::C::Object.New(@isolate)
+      str = o.ObjectProtoToString(@ctx)
+
+      expect(str).to be_successful
+      expect(str.FromJust.Utf8Value).to eq '[object Object]'
+    end
+
+    it 'can return a string representation of simple objects' do
+      a = V8::C::Array.New(@isolate)
+      a.Set(@ctx, 0, 2)
+      a.Set(@ctx, 1, 3)
+
+      str = a.ObjectProtoToString(@ctx)
+      expect(str).to be_successful
+      expect(str.FromJust.Utf8Value).to eq '[object Array]'
+    end
+  end
 end

--- a/spec/c/object_spec.rb
+++ b/spec/c/object_spec.rb
@@ -81,6 +81,17 @@ describe V8::C::Object do
     end
   end
 
+  describe '#CreateDataProperty' do
+    it 'can set the property' do
+      o = V8::C::Object.New(@isolate)
+      key = V8::C::String.NewFromUtf8(@isolate, 'foo')
+      data = V8::C::String.NewFromUtf8(@isolate, 'data')
+
+      expect(o.CreateDataProperty(@ctx, key, data)).to be_successful
+      expect(o.Get(@ctx, key)).to be_successful
+    end
+  end
+
   # TODO: Enable this when the methods are implemented in the extension
   # it 'can retrieve all property names' do
   #   o = V8::C::Object.New

--- a/spec/c/object_spec.rb
+++ b/spec/c/object_spec.rb
@@ -92,6 +92,17 @@ describe V8::C::Object do
     end
   end
 
+  describe '#DefineOwnProperty' do
+    it 'can set the property' do
+      o = V8::C::Object.New(@isolate)
+      key = V8::C::String.NewFromUtf8(@isolate, 'foo')
+      data = V8::C::String.NewFromUtf8(@isolate, 'data')
+
+      expect(o.DefineOwnProperty(@ctx, key, data)).to be_successful
+      expect(o.Get(@ctx, key)).to be_successful
+    end
+  end
+
   # TODO: Enable this when the methods are implemented in the extension
   # it 'can retrieve all property names' do
   #   o = V8::C::Object.New

--- a/spec/c/object_spec.rb
+++ b/spec/c/object_spec.rb
@@ -114,6 +114,83 @@ describe V8::C::Object do
     end
   end
 
+  describe '#GetOwnPropertyDescriptor' do
+    it 'can read the descriptor of a data property' do
+      o = V8::C::Object.New(@isolate)
+      key = V8::C::String.NewFromUtf8(@isolate, 'foo')
+      data = V8::C::String.NewFromUtf8(@isolate, 'data')
+
+      expect(o.DefineOwnProperty(@ctx, key, data, V8::C::PropertyAttribute::DontEnum)).to be_successful
+
+      maybe = o.GetOwnPropertyDescriptor(@ctx, key)
+      expect(maybe).to be_successful
+
+      descriptor = maybe.FromJust
+      value = descriptor.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'value'))
+      writable = descriptor.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'writable'))
+      get = descriptor.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'get'))
+      set = descriptor.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'set'))
+      configurable = descriptor.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'configurable'))
+      enumerable = descriptor.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'enumerable'))
+
+      expect(value).to strict_eq data
+
+      expect(writable).to be_successful
+      expect(writable.FromJust.Value).to be true
+
+      expect(get).to be_successful
+      expect(get.FromJust).to be_a V8::C::Undefined
+
+      expect(set).to be_successful
+      expect(set.FromJust).to be_a V8::C::Undefined
+
+      expect(configurable).to be_successful
+      expect(configurable.FromJust.Value).to be true
+
+      expect(enumerable).to be_successful
+      expect(enumerable.FromJust.Value).to be false
+    end
+
+    # it 'can read the descriptor of an accessor property' do
+    #   o = V8::C::Object.New(@isolate)
+    #   key = V8::C::String.NewFromUtf8(@isolate, 'foo')
+    #   data = V8::C::String.NewFromUtf8(@isolate, 'data')
+    #
+    #   getter = V8::C::Function.New @isolate, proc { }, V8::C::Object::New(@isolate)
+    #   setter = V8::C::Function.New @isolate, proc { }, V8::C::Object::New(@isolate)
+    #
+    #   expect(o.SetAccessorProperty(@ctx, key, getter, setter)).to be_successful
+    #
+    #   maybe = o.GetOwnPropertyDescriptor(@ctx, key)
+    #   expect(maybe).to be_successful
+    #
+    #   descriptor = maybe.FromJust
+    #   value = descriptor.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'value'))
+    #   writable = descriptor.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'writable'))
+    #   get = descriptor.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'get'))
+    #   set = descriptor.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'set'))
+    #   configurable = descriptor.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'configurable'))
+    #   enumerable = descriptor.Get(@ctx, V8::C::String.NewFromUtf8(@isolate, 'enumerable'))
+    #
+    #   expect(value).to be_successful
+    #
+    #   expect(writable).to be_successful
+    #   expect(writable.FromJust.Value).to be true
+    #
+    #   expect(get).to be_successful
+    #   expect(get.FromJust).to be_a V8::C::Undefined
+    #
+    #   expect(set).to be_successful
+    #   expect(set.FromJust).to be_a V8::C::Undefined
+    #
+    #   expect(configurable).to be_successful
+    #   expect(configurable.FromJust.Value).to be true
+    #
+    #   expect(enumerable).to be_successful
+    #   expect(enumerable.FromJust.Value).to be true
+    # end
+  end
+
   # TODO: Enable this when the methods are implemented in the extension
   # it 'can retrieve all property names' do
   #   o = V8::C::Object.New

--- a/spec/c/symbol_spec.rb
+++ b/spec/c/symbol_spec.rb
@@ -35,7 +35,7 @@ describe V8::C::Symbol do
     end
 
     it "returns different symbols for different registries" do
-      expect(global.StrictEquals(api)).to be false
+      expect(global).to_not strict_eq api
     end
   end
 

--- a/spec/c_spec_helper.rb
+++ b/spec/c_spec_helper.rb
@@ -1,30 +1,3 @@
 require 'v8/init'
 
-module V8ContextHelpers
-  module GroupMethods
-    def requires_v8_context
-      around(:each) do |example|
-        bootstrap_v8_context(&example)
-      end
-    end
-  end
-
-  def bootstrap_v8_context
-    @isolate = V8::C::Isolate.New
-
-    V8::C::HandleScope(@isolate) do
-      @ctx = V8::C::Context::New(@isolate)
-      begin
-        @ctx.Enter
-        yield
-      ensure
-        @ctx.Exit
-      end
-    end
-  end
-end
-
-RSpec.configure do |c|
-  c.include V8ContextHelpers
-  c.extend V8ContextHelpers::GroupMethods
-end
+Dir["#{File.dirname(__FILE__)}/support/*.rb"].each { |helper| require_relative helper }

--- a/spec/support/context.rb
+++ b/spec/support/context.rb
@@ -1,0 +1,28 @@
+module V8ContextHelpers
+  module GroupMethods
+    def requires_v8_context
+      around(:each) do |example|
+        bootstrap_v8_context(&example)
+      end
+    end
+  end
+
+  def bootstrap_v8_context
+    @isolate = V8::C::Isolate.New
+
+    V8::C::HandleScope(@isolate) do
+      @ctx = V8::C::Context::New(@isolate)
+      begin
+        @ctx.Enter
+        yield
+      ensure
+        @ctx.Exit
+      end
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include V8ContextHelpers
+  c.extend V8ContextHelpers::GroupMethods
+end

--- a/spec/support/v8_matchers.rb
+++ b/spec/support/v8_matchers.rb
@@ -1,0 +1,45 @@
+module V8Matchers
+  extend RSpec::Matchers::DSL
+
+  matcher :eq_just do |expected|
+    match do |maybe|
+      return false unless maybe.IsJust
+
+      maybe.FromJust == expected
+    end
+  end
+
+  matcher :be_successful do
+    match do |maybe|
+      return false unless maybe.IsJust
+
+      maybe.FromJust
+    end
+  end
+
+  matcher :strict_eq do |expected|
+    match do |object|
+      if object.respond_to? 'IsJust'
+        return false unless object.IsJust
+        object = object.FromJust
+      end
+
+      object.StrictEquals(expected)
+    end
+  end
+
+  matcher :v8_eq do |expected|
+    match do |object|
+      if object.respond_to? 'IsJust'
+        return false unless object.IsJust
+        object = object.FromJust
+      end
+
+      object.Equals(expected)
+    end
+  end
+end
+
+RSpec.configure do |c|
+  c.include V8Matchers
+end


### PR DESCRIPTION
In this branch I put the Object method implementations.

Currently implemented:
  - `SetAccessorProperty`
  - `GetOwnPropertyAccessor`
  - `GetPropertyAttributes`
  - `DefineOwnProperty`
  - `CreateDataProperty`
  - `GetConstructorName`
  - `InternalFieldCount`
  - `GetInternalField`
  - `SetInternalField`
  - `HasOwnProperty`
  - `HasRealNamedProperty`
  - `HasRealIndexedProperty`
  - `HasRealNamedCallbackProperty`
  - `GetRealNamedPropertyInPrototypeChain`
  - `GetRealNamedProperty`
  - `GetRealNamedPropertyAttributes`
  - `GetRealNamedPropertyAttributesInPrototypeChain`
  - `HasNamedLookupInterceptor`
  - `HasIndexedLookupInterceptor`
  - `SetHiddenValue`
  - `GetHiddenValue`
  - `DeleteHiddenValue`
  - `Clone`
  - `CreationContext`
  - `IsCallable`
  - `CallAsFunction`
  - `CallAsConstructor`

Also, I added a few RSpec matchers for a more convenient use of `Maybe` instances:
  - `expect(a).to eq_just b` <=> `a.IsJust && a.FromJust == b`
  - `expect(a).to be_successful` <=> `a.IsJust && a.FromJust`
  - `expect(a).to strict_eq b` <=> if a is Maybe: `a.IsJust && a.FromJust.StrictEquals(b)`; else `a.StrictEquals(b)`
  - `expect(a).to v8_eq b` <=> same as above but for `Equals` instead of `StrictEquals`