### PR TITLE
Change names access helper to iterate over the ancestors instead of doing dup/shift

### DIFF
--- a/lib/v8/access/names.rb
+++ b/lib/v8/access/names.rb
@@ -46,8 +46,7 @@ class V8::Access
 
     def accessible_names(obj, special_methods = false)
       obj.public_methods(false).map {|m| m.to_s}.to_set.tap do |methods|
-        ancestors = obj.class.ancestors.dup
-        while ancestor = ancestors.shift
+        obj.class.ancestors.each do |ancestor|
           break if ancestor == ::Object
           methods.merge(ancestor.public_instance_methods(false).map {|m| m.to_s})
         end


### PR DESCRIPTION
Due to setup of the helper calling the get or set methods on any js object bound to a ruby object will call the accessibe_names each time. This will result in the duplication of the ancestors array which will be used for iteration and then discarded, which is quite inefficient if you plan on calling into ruby often.

Note, an identical and even faster effect could be achieved by refactoring the class to testing where a method is defined using a process like this:

```ruby
def method_below_object
  begin
    ancestors = obj.class.ancestors
    index_of_object = ancestors.index(Object)
    index_of_method_owner = ancestors.index(obj.method(name).owner)
    return index_of_method_owner < index_of_object
  rescue
    return false
  end
end
```

I can implement the change if there is interest.