### PR TITLE
Making the `timeout` attribute writable

### DIFF
--- a/lib/v8/context.rb
+++ b/lib/v8/context.rb
@@ -42,7 +42,7 @@ module V8
 
     # @!attribute [r] timeout
     #   @return [Number] maximum execution time in milliseconds for scripts executed in this context
-    attr_reader :timeout
+    attr_accessor :timeout
 
     # Creates a new context.
     #

--- a/spec/threading_spec.rb
+++ b/spec/threading_spec.rb
@@ -10,6 +10,32 @@ describe "Timeouts" do
     ctx.eval("x=2;")
     ctx["x"].should == 2
   end
+
+  it "allows changing the timeout on an existing context" do
+    ctx = V8::Context.new(:timeout => 200)
+
+    js = <<-js
+      // sleep for 50 ms
+      var now = new Date().getTime();
+      while(new Date().getTime() < now + 50) {}
+
+      if(typeof x === 'undefined') {
+        x = 1;
+      } else {
+        x = 2;
+      }
+    js
+
+    ctx.eval(js)
+    ctx["x"].should == 1
+
+    ctx.timeout = 10
+    lambda {ctx.eval(js)}.should(raise_error)
+
+    ctx.timeout = 200
+    ctx.eval(js)
+    ctx["x"].should == 2
+  end
 end
 
 describe "using v8 from multiple threads", :threads => true do


### PR DESCRIPTION
Can come in handy to evaluate several pieces of JS with the same context,
but different timeouts for each.

Added a unit test.