### PR TITLE
Allowing to quickly duplicates contexts

### DIFF
--- a/ext/v8/rr.h
+++ b/ext/v8/rr.h
@@ -306,6 +306,7 @@ public:
   static void Init();
   static VALUE New(int argc, VALUE argv[], VALUE self);
   static VALUE Dispose(VALUE self);
+  static VALUE Clone(VALUE self, VALUE new_context);
   static VALUE Enter(VALUE self);
   static VALUE Exit(VALUE self);
   static VALUE Global(VALUE self);

--- a/lib/v8/context.rb
+++ b/lib/v8/context.rb
@@ -62,9 +62,12 @@ module V8
     #  * :with scope serves as the global scope of the new context
     # @yield [V8::Context] the newly created context
     def initialize(options = {})
+      @options = options
+
       @conversion = Conversion.new
       @access = Access.new
       @timeout = options[:timeout]
+
       if global = options[:with]
         Context.new.enter do
           global_template = global.class.to_template.InstanceTemplate()
@@ -134,6 +137,14 @@ module V8
       V8::C::V8::ContextDisposedNotification()
       def self.enter
         fail "cannot enter a context which has already been disposed"
+      end
+    end
+
+    def deep_clone
+      fail ArgumentError, 'cannot clone an empty context' unless @native
+
+      self.class.new(@options).tap do |new_context|
+        native.Clone(new_context.native)
       end
     end
 

--- a/spec/v8/context_spec.rb
+++ b/spec/v8/context_spec.rb
@@ -1,19 +1,92 @@
 require 'spec_helper'
 
 describe V8::Context do
-  it "can be disposed of" do
-    cxt = V8::Context.new
-    cxt.enter do
-      cxt['object'] = V8::Object.new
-    end
-    cxt.dispose()
+  describe '.dispose' do
+    it "can be disposed of" do
+      cxt = V8::Context.new
+      cxt.enter do
+        cxt['object'] = V8::Object.new
+      end
+      cxt.dispose()
 
-    lambda {cxt.eval('1 + 1')}.should raise_error
-    lambda {cxt['object']}.should raise_error
+      lambda {cxt.eval('1 + 1')}.should raise_error
+      lambda {cxt['object']}.should raise_error
+    end
+
+    it "can be disposed of any number of times" do
+      cxt = V8::Context.new
+      10.times {cxt.dispose()}
+    end
   end
 
-  it "can be disposed of any number of times" do
-    cxt = V8::Context.new
-    10.times {cxt.dispose()}
+  describe '.deep_clone' do
+    let(:js) do
+      <<-js
+        if (typeof x === 'undefined') {
+            x = 1;
+        } else {
+            x = x + 1;
+        }
+      js
+    end
+
+    it 'duplicates the underlying native object' do
+      cxt = V8::Context.new
+
+      cxt.eval(js)
+
+      cloned_cxt = cxt.deep_clone
+
+      cxt.eval(js)
+      cxt["x"].should == 2
+
+      cloned_cxt["x"].should == 1
+      cloned_cxt.eval(js)
+      cloned_cxt["x"].should == 2
+
+      cxt.eval(js)
+      cxt["x"].should == 3
+    end
+
+    it 'works on empty contexts' do
+      cxt = V8::Context.new
+
+      cloned_cxt = cxt.deep_clone
+
+      cxt.eval(js)
+      cxt["x"].should == 1
+
+      cloned_cxt["x"].should be(nil)
+    end
+
+    it 'keeps original options' do
+      cxt = V8::Context.new(:timeout => 10)
+
+      cloned_cxt = cxt.deep_clone
+
+      cloned_cxt.timeout.should == 10
+    end
+
+    context 'when the original context has been disposed of' do
+      it 'should not allow cloning any more' do
+        cxt = V8::Context.new
+
+        cxt.dispose
+
+        lambda { cxt.deep_clone }.should raise_error
+      end
+
+      it 'should not affect previously cloned contexts' do
+        cxt = V8::Context.new
+        cxt.eval(js)
+
+        cloned_cxt = cxt.deep_clone
+
+        cxt.dispose
+
+        cloned_cxt.eval(js)
+        cloned_cxt["x"].should == 2
+      end
+    end
   end
 end


### PR DESCRIPTION
With a new `deep_clone` method.

Comes in handy for caching base contexts then used to evalaute further scripts.

With proper unit tests on it.