### PR TITLE
Remove old ruby versions from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ cache: bundler
 rvm:
   - 2.1
   - 2.0.0
-  - 1.9.3
 #  - rbx-2.5.2
 notifications:
   recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ rvm:
   - 2.1
   - 2.0.0
   - 1.9.3
-  - 1.9.2
-  - 1.8.7
 #  - rbx-2.5.2
 notifications:
   recipients:


### PR DESCRIPTION
Removed version 1.9.2,1.8.7 and 1.9.3
This fixes the travisci errors