### PR TITLE
Updated libv8 version

### DIFF
--- a/ext/v8/extconf.rb
+++ b/ext/v8/extconf.rb
@@ -16,7 +16,7 @@ if enable_config('debug')
   $CFLAGS += " -O0 -ggdb3"
 end
 
-LIBV8_COMPATIBILITY = '~> 3.16.14'
+LIBV8_COMPATIBILITY = '~> 3.16.14.15'
 
 begin
   require 'rubygems'

--- a/therubyracer.gemspec
+++ b/therubyracer.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_dependency 'ref'
-  gem.add_dependency 'libv8', '~> 3.16.14.0'
+  gem.add_dependency 'libv8', '~> 3.16.14.15'
 end


### PR DESCRIPTION
Hi,

installing `therubyracer` fails on macOS Sierra because building `libv8` fails.
For some reason version `3.16.14.15` works on macOS Sierra (see [this issue](https://github.com/cowboyd/libv8/issues/225)) and since only patches have been applied since the currently used version of `libv8` (`3.16.14.0`) I guess there should be no bad consequences, right? ^^
Some of the changes are documented in `libv8`'s [changelog](https://github.com/cowboyd/libv8/blob/master/CHANGELOG.md).

I would be awesome if the PR would be merged so I can get my rails app back up running on my new system. Thanks! :)
