### PR TITLE
Fix a build error in Travis CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :development do
   gem "rubysl", :platforms => :rbx
   gem 'redjs', :git => 'https://github.com/cowboyd/redjs.git'
   gem "rake"
-  gem "rspec", "~> 2.0"
+  gem "rspec", "~> 3.5.0"
   gem "rake-compiler"
   gem "gem-compiler", :platforms => :mri
 end


### PR DESCRIPTION
Fix a build error in Travis CI

This PR will fix a following build error.

```sh
$ bundle exec rake compile spec
rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x000000027fd0a8>
/home/travis/build/cowboyd/therubyracer/vendor/bundle/ruby/2.1.0/gems/rspec-core-2.99.2/lib/rspec/core/rake_task.rb:143:in
`initialize'
/home/travis/build/cowboyd/therubyracer/Rakefile:18:in `new'
/home/travis/build/cowboyd/therubyracer/Rakefile:18:in `<top (required)>'
/home/travis/build/cowboyd/therubyracer/vendor/bundle/ruby/2.1.0/gems/rake-12.0.0/exe/rake:27:in `<top (required)>'
```

An above error is caused by a combination of Rake and RSpec versions.

:warning: The important point, `last_comment` method has been removed from latest version of Rake (12.0.0).

https://github.com/ruby/rake/commit/11bbb7c20bb9bae42310e0ab9294a76658fe158e

This problem will be solved by upgrade RSpec. That is the way this PR taking.

See also: https://travis-ci.org/cowboyd/therubyracer/jobs/185070858

Thanks.