### PR TITLE
Fix deprecation warning method_missing

### DIFF
--- a/lib/v8/object.rb
+++ b/lib/v8/object.rb
@@ -52,7 +52,7 @@ class V8::Object
     end
   end
 
-  def respond_to?(method)
+  def respond_to?(method, include_all=false)
     super or self[method] != nil
   end
 


### PR DESCRIPTION
Fix deprecation warning on outdated method missing definition.