### PR TITLE
Add redirection to mini_racer in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+⚠️ Unmaintained, consider using [`mini_racer`](https://github.com/rubyjs/mini_racer) <sup><a href="https://github.com/rubyjs/therubyracer/issues/462">see issue</a></sup> ⚠️
+
 # therubyracer
 
 [![Gem Version](https://badge.fury.io/rb/therubyracer.png)](http://badge.fury.io/rb/therubyracer)

--- a/therubyracer.gemspec
+++ b/therubyracer.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |gem|
   gem.version       = V8::VERSION
   gem.license       = 'MIT'
 
+  gem.post_install_message = "Unmaintened gem. Please consider using `mini_racer` instead."
+
   gem.add_dependency 'ref'
   gem.add_dependency 'libv8', '~> 3.16.14.15'
 end


### PR DESCRIPTION
Per #462 and commit activity, it seems clear that this gem is not maintained. I think it would be great to mention that directly in the README.